### PR TITLE
Added required import statement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='synology-synology_api',


### PR DESCRIPTION
I couldn't run setup.py without adding an extra import statement for find_packages. Did it work for you without the import I'm suggesting you add?

> $ pip3 install git+https://github.com/N4S4/synology-api
Collecting git+https://github.com/N4S4/synology-api
  Cloning https://github.com/N4S4/synology-api to /private/var/folders/6x/vgh0fdvx18qcbtm120mfzd540000gn/T/pip-4su2gd0_-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/6x/vgh0fdvx18qcbtm120mfzd540000gn/T/pip-4su2gd0_-build/setup.py", line 6, in <module>
        packages=find_packages(exclude=['tests*']),
    NameError: name 'find_packages' is not defined
>    
>    ----------------------------------------
> Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/6x/vgh0fdvx18qcbtm120mfzd540000gn/T/pip-4su2gd0_-build/