### PR TITLE
Convert python boolean in true/false string for Synology API

### DIFF
--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -87,6 +87,11 @@ class Authentication:
 
     def request_data(self, api_name, api_path, req_param, method=None, response_json=True):  # 'post' or 'get'
 
+        # Convert all booleen in string in lowercase because Synology API is waiting for "true" or "false"
+        for k,v in req_param.items():
+            if isinstance(v, bool):
+                req_param[k] = str(v).lower()
+
         if method is None:
             method = 'get'
 


### PR DESCRIPTION
Hello, I remark that I missed some shares when I did the get_list_share() function.
After debugging I saw that the error was from only-writable: False that was not see as "false" by the API.

I think there are maybe other issue with the same kind of options, so I think it could be good to convert them as "false" and "true" automatically.

Cheers