### PR TITLE
Add FileStation.Download method for open and download mode

### DIFF
--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import requests
 import sys
 import urllib
+from urllib import parse
 
 from . import auth as syn
 
@@ -996,8 +997,8 @@ class FileStation:
 
         session = requests.session()
 
-        url = ('%s%s' % (self.base_url, api_path)) + '?api=%s&version=%s&method=download&_sid=%s&path=%s&mode=%s' % (
-                api_name, info['maxVersion'], self._sid, urllib.parse.quote_plus(path), mode)
+        url = ('%s%s' % (self.base_url, api_path)) + '?api=%s&version=%s&method=download&path=%s&mode=%s&_sid=\'%s\'' % (
+                api_name, info['maxVersion'], urllib.parse.quote_plus(path), mode, self._sid)
 
         if mode is None:
             return 'Enter a valid mode (open / download)'

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -997,7 +997,7 @@ class FileStation:
 
         session = requests.session()
 
-        url = ('%s%s' % (self.base_url, api_path)) + '?api=%s&version=%s&method=download&path=%s&mode=%s&_sid=\'%s\'' % (
+        url = ('%s%s' % (self.base_url, api_path)) + '?api=%s&version=%s&method=download&path=%s&mode=%s&_sid=%s' % (
                 api_name, info['maxVersion'], urllib.parse.quote_plus(path), mode, self._sid)
 
         if mode is None:


### PR DESCRIPTION
It add the download method for the open/download mode.

For the open mode I use sys because print provoke a broken pipe.
With this code I can use `python code.py | mpv -`

For the download mode I thought it would be better to save it with the chunk method instead to load it completely before saving it.

Feel free to change some code part if needed so that it match the rest of the code.

Cheers.