### PR TITLE
Base url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+dist/
+*.egg-info/
+__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ dwn = downloadstation.DownloadStation('Synology Ip', 'Synology Port', 'Username'
 
 dwn.get_info()
 
+# You can also initate the classes with your DSM Base URL
+# on this case, you need to set up argument order :
+fl = filestation.FileStation(base_url='https://synology_ip:synology_port/', username='Username', password='Password')
+
 ```
 
 response would be json data

--- a/synology_api/audiostation.py
+++ b/synology_api/audiostation.py
@@ -3,8 +3,8 @@ from . import auth as syn
 
 class AudioStation:
 
-    def __init__(self, ip_address, port, username, password):
-        self.session = syn.Authentication(ip_address, port, username, password)
+    def __init__(self, ip_address=None, port=None, username=None, password=None, base_url=None):
+        self.session = syn.Authentication(ip_address, port, username, password, base_url)
 
         self.session.login('AudioStation')
         self.session.get_api_list('AudioStation')

--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -15,7 +15,7 @@ class Authentication:
                 self._base_url = '%s/webapi/' % base_url
         else:
             if not ip_address:
-                raise Exception('Missing both base_url and ip_address on Authentication')
+                raise AuthenticationError('Missing both base_url and ip_address on Authentication')
             if not port:
                 port = 5000
             self._base_url = 'http://%s:%s/webapi/' % (ip_address, port)
@@ -131,3 +131,6 @@ class Authentication:
     @property
     def base_url(self):
         return self._base_url
+
+class AuthenticationError(Exception):
+    pass

--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -2,14 +2,23 @@ import requests
 
 
 class Authentication:
-    def __init__(self, ip_address, port, username, password):
-        self._ip_address = ip_address
-        self._port = port
+    def __init__(self, ip_address=None, port=None, username=None, password=None, base_url=None):
         self._username = username
         self._password = password
         self._sid = None
         self._session_expire = True
-        self._base_url = 'http://%s:%s/webapi/' % (self._ip_address, self._port)
+
+        if base_url:
+            if base_url.endswith('/'):
+                self._base_url = '%swebapi/' % base_url
+            else:
+                self._base_url = '%s/webapi/' % base_url
+        else:
+            if not ip_address:
+                raise Exception('Missing both base_url and ip_address on Authentication')
+            if not port:
+                port = 5000
+            self._base_url = 'http://%s:%s/webapi/' % (ip_address, port)
 
         self.full_api_list = {}
         self.app_api_list = {}

--- a/synology_api/downloadstation.py
+++ b/synology_api/downloadstation.py
@@ -3,9 +3,9 @@ from . import auth as syn
 
 class DownloadStation:
 
-    def __init__(self, ip_address, port, username, password):
+    def __init__(self, ip_address=None, port=None, username=None, password=None, base_url=None):
 
-        self.session = syn.Authentication(ip_address, port, username, password)
+        self.session = syn.Authentication(ip_address, port, username, password, base_url)
         self._bt_search_id = ''
         self._bt_search_id_list = []
         self.session.login('DownloadStation')

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -11,9 +11,9 @@ from . import auth as syn
 
 class FileStation:
 
-    def __init__(self, ip_address, port, username, password):
+    def __init__(self, ip_address=None, port=None, username=None, password=None, base_url=None):
 
-        self.session = syn.Authentication(ip_address, port, username, password)
+        self.session = syn.Authentication(ip_address, port, username, password, base_url)
 
         self._dir_taskid = ''
         self._dir_taskid_list = []

--- a/synology_api/sys_info.py
+++ b/synology_api/sys_info.py
@@ -2,9 +2,9 @@ from . import auth as syn
 
 
 class SysInfo:
-    def __init__(self, ip_address, port, username, password):
+    def __init__(self, ip_address=None, port=None, username=None, password=None, base_url=None):
 
-        self.session = syn.Authentication(ip_address, port, username, password)
+        self.session = syn.Authentication(ip_address, port, username, password, base_url)
 
         self.session.login('Core')
         self.session.get_api_list('Core')

--- a/synology_api/virtualization.py
+++ b/synology_api/virtualization.py
@@ -3,9 +3,9 @@ from . import auth as syn
 
 class Virtualization:
 
-    def __init__(self, ip_address, port, username, password):
+    def __init__(self, ip_address=None, port=None, username=None, password=None, base_url=None):
 
-        self.session = syn.Authentication(ip_address, port, username, password)
+        self.session = syn.Authentication(ip_address, port, username, password, base_url)
 
         self.request_data = self.session.request_data
 


### PR DESCRIPTION
About #20 
Another way to initiate objects. On some setups, the Synology DSM is available on custom urls (if there is a reverse proxy for example)

It's useful for HTTPS (like #22 )

I tested on a remote NAS with LetsEncrypt certificate, and with FileStation and DownloadStation (I dont have other stuffs enabled on my Syno)

With this way, it's mandatory to set the param names when creating the authentication object, for the compatibility way with the method described on the Readme.