### PR TITLE
fix(synology_api/filestation.py/FileStation/create_folder): Fix missi…

### DIFF
--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -618,7 +618,7 @@ class FileStation:
             name = '[' + ','.join(name) + ']'
             req_param['name'] = name
         elif name is not None:
-            req_param['name'] = name
+            req_param['name'] = '"' + name + '"'
         else:
             return 'Enter a valid path'
 


### PR DESCRIPTION
Fix missing double quotes at line 621.

Cannot create a folder name which only contain numbers without quotation marks.
Add double quotes to make sure API run as well.

Pass simple test as below:

```python
from synology_api import filestation
fl = filestation.FileStation(DOMAIN, PORT, USER, PASSWORD)
folder_path = "/test"
name = "123456"
fl.create_folder(folder_path, name)
```

fix #26