### PR TITLE
DownloadStation: Fix task_id referencing in tasks_info (Improving Code Branch) 

### DIFF
--- a/synology_api/downloadstation.py
+++ b/synology_api/downloadstation.py
@@ -68,7 +68,7 @@ class DownloadStation(Synology):
         if additional_param is None:
             additional_param = ['detail', 'transfer', 'file', 'tracker', 'peer']
 
-        param = {'additional': ",".join(additional_param)}
+        param = {'id': task_id, 'additional': ",".join(additional_param)}
 
         return self.api_request('Task', 'getinfo', param)
 


### PR DESCRIPTION
Just a quick fix for tasks_list, as task_id was not referenced at all.