### PR TITLE
SysInfo: Add get_info() method for JSON output of DSM (Improving Code Branch)

### DIFF
--- a/synology_api/sys_info.py
+++ b/synology_api/sys_info.py
@@ -237,6 +237,12 @@ class Backup(Synology):
     def network_backup_info(self):
         return self.api_request('Service.NetworkBackup', 'get')
 
+class DSM(Synology):
+    app = "DSM"
+
+    @api_call()
+    def get_info(self):
+        return self.api_request('Info', 'getinfo')
 
 class Storage(Synology):
     app = "Storage"


### PR DESCRIPTION
For those who want to pull DSM information from sys_info.py

`{'data': {'codepage': 'enu', 'model': 'DS918+', 'ram': 4096, 'serial': 'obscured_serial_number', 'temperature': 40, 'temperature_warn': False, 'time': 'Mon Apr  6 00:40:59 2020', 'uptime': 363981, 'version': '24922', 'version_string': 'DSM 6.2.2-24922 Update 5'}, 'success': True}`