### PR TITLE
Use str.format instead of f-string

### DIFF
--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -435,9 +435,9 @@ class FileStation:
         req_param = {'version': info['maxVersion'], 'method': 'status'}
 
         if taskid is None and self._md5_calc_taskid is not '':
-            req_param['taskid'] = f'"{self._md5_calc_taskid}"'
+            req_param['taskid'] = '"{taskid}"'.format(taskid=self._md5_calc_taskid)
         elif taskid is not None:
-            req_param['taskid'] = f'"{taskid}"'
+            req_param['taskid'] = '"{taskid}"'.format(taskid=taskid)
         else:
             return 'Did you run start_md5_calc() first? No task id found! ' + str(self._md5_calc_taskid)
 


### PR DESCRIPTION
f-strings or format string literals are only supported by python version >= 3.6
[https://docs.python.org/3/reference/lexical_analysis.html#f-strings](url)
[https://docs.python.org/3/whatsnew/3.6.html#pep-498-formatted-string-literals](url)
Fixes #36 