### PR TITLE
Proposal : allow skipping SSL certificates 

### DIFF
--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -478,13 +478,16 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def upload_file(self, dest_path, file_path, create_parents=True, overwrite=True, verify=True):
+    def upload_file(self, dest_path, file_path, create_parents=True, overwrite=True, verify=False):
         api_name = 'SYNO.FileStation.Upload'
         info = self.file_station_list[api_name]
         api_path = info['path']
         filename = os.path.basename(file_path)
 
         session = requests.session()
+        
+        if self.base_url[:5] == 'https':
+            verify = True
 
         with open(file_path, 'rb') as payload:
             url = ('%s%s' % (self.base_url, api_path)) + '?api=%s&version=%s&method=upload&_sid=%s' % (
@@ -980,7 +983,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_file(self, path=None, mode=None, dest_path=".", chunk_size=8192, verify=True):
+    def get_file(self, path=None, mode=None, dest_path=".", chunk_size=8192, verify=False):
 
         api_name = 'SYNO.FileStation.Download'
         info = self.file_station_list[api_name]
@@ -988,6 +991,9 @@ class FileStation:
 
         if path is None:
             return 'Enter a valid path'
+        
+        if self.base_url[:5] == 'https':
+            verify = True
 
         session = requests.session()
 

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -980,7 +980,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_file(self, path=None, mode=None, chunkSize=8192, dest_path=".",verify=True):
+    def get_file(self, path=None, mode=None, dest_path=".", chunk_size=8192, verify=True):
         api_name = 'SYNO.FileStation.Download'
         info = self.file_station_list[api_name]
         api_path = info['path']

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -980,7 +980,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_file(self, path=None, mode=None, chunkSize=8192, dest_path="."):
+    def get_file(self, path=None, mode=None, chunkSize=8192, dest_path=".",verify=False):
         api_name = 'SYNO.FileStation.Download'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -997,14 +997,14 @@ class FileStation:
             return 'Enter a valid mode (open / download)'
 
         if mode == r'open':
-            with session.get(url, stream=True) as r:
+            with session.get(url, stream=True,verify=verify) as r:
                 r.raise_for_status()
                 for chunk in r.iter_content(chunk_size=chunkSize):
                     if chunk:  # filter out keep-alive new chunks
                         sys.stdout.buffer.write(chunk)
 
         if mode == r'download':
-            with session.get(url, stream=True) as r:
+            with session.get(url, stream=True,verify=verify) as r:
                 r.raise_for_status()
                 if not os.path.isdir(dest_path):
                     os.makedirs(dest_path)

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -980,7 +980,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_file(self, path=None, mode=None, chunkSize=8192, dest_path=".",verify=False):
+    def get_file(self, path=None, mode=None, chunkSize=8192, dest_path=".",verify=True):
         api_name = 'SYNO.FileStation.Download'
         info = self.file_station_list[api_name]
         api_path = info['path']

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -478,7 +478,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def upload_file(self, dest_path, file_path, create_parents=True, overwrite=True verify=True):
+    def upload_file(self, dest_path, file_path, create_parents=True, overwrite=True, verify=True):
         api_name = 'SYNO.FileStation.Upload'
         info = self.file_station_list[api_name]
         api_path = info['path']

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -478,7 +478,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def upload_file(self, dest_path, file_path, create_parents=True, overwrite=True):
+    def upload_file(self, dest_path, file_path, create_parents=True, overwrite=True verify=True):
         api_name = 'SYNO.FileStation.Upload'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -498,7 +498,7 @@ class FileStation:
 
             files = {'file': (filename, payload, 'application/octet-stream')}
 
-            r = session.post(url, data=args, files=files)
+            r = session.post(url, data=args, files=files, verify=verify)
 
             if r.status_code is 200 and r.json()['success']:
                 return 'Upload Complete'


### PR DESCRIPTION
In my current netttwork the Synology NAS is local https - so we don't have SSL certificates.

I need to be able to set the flag "verify" when get_file or upload_file, in order to work around the SSLCertVerificationError (see the stack below) 

Thanks, 
Daniele

--

Traceback (most recent call last):
[...]
  File "C:\Users\danie\AppData\Local\Programs\Python\Python38\lib\site-packages\synology_api\filestation.py", line 1007, in get_file
    with session.get(url, stream=True, verify=verify) as r:
  File "C:\Users\danie\AppData\Local\Programs\Python\Python38\lib\site-packages\requests\sessions.py", line 543, in get
    return self.request('GET', url, **kwargs)
  File "C:\Users\danie\AppData\Local\Programs\Python\Python38\lib\site-packages\requests\sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "C:\Users\danie\AppData\Local\Programs\Python\Python38\lib\site-packages\requests\sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "C:\Users\danie\AppData\Local\Programs\Python\Python38\lib\site-packages\requests\adapters.py", line 514, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='10.37.0.103', port=5001): Max retries exceeded with url: /webapi/entry.cgi?api=SYNO.FileStation.Download&version=2&method=download&path=%2FShared%2FErrorNS.png&mode=download&_sid=G1p2GJ4V0x-Eg7XZN9oEtCAwaxzwL_-hXNn7n2eCqYIh77YWLynJDQtzOLArKj0NIL2qZtp-2-pcctmzLmUxWw (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1108)')))