### PR TITLE
Update filestation.py

### DIFF
--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -485,9 +485,6 @@ class FileStation:
         filename = os.path.basename(file_path)
 
         session = requests.session()
-        
-        if self.base_url[:5] == 'https':
-            verify = True
 
         with open(file_path, 'rb') as payload:
             url = ('%s%s' % (self.base_url, api_path)) + '?api=%s&version=%s&method=upload&_sid=%s' % (
@@ -991,9 +988,6 @@ class FileStation:
 
         if path is None:
             return 'Enter a valid path'
-        
-        if self.base_url[:5] == 'https':
-            verify = True
 
         session = requests.session()
 


### PR DESCRIPTION
I proposed pull request #54 to handle a situation where we have a local https connection with no certificates. So we need to define secure=True (ctor of FileStation) but verify=False when get_file. 
Commit 09ca8b9331c1547b131d211d6b3d7ad819861e1e forces verify=True if self.base_url[:5] == 'https', thus preventing us to connect to the NAS. 
Please accept the change and remove this limitation.