### PR TITLE
Fix for not being able to log into Photos on DSM 7

### DIFF
--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -32,10 +32,6 @@ class Authentication:
         if self._otp_code:
             param['otp_code'] = self._otp_code
 
-        # log into Photos only works without the session key
-        if application in ['Foto']:
-            del ( param['session'] )
-
         if not self._session_expire:
             if self._sid is not None:
                 self._session_expire = False

--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -32,6 +32,10 @@ class Authentication:
         if self._otp_code:
             param['otp_code'] = self._otp_code
 
+        # log into Photos only works without the session key
+        if application in ['Foto']:
+            del ( param['session'] )
+
         if not self._session_expire:
             if self._sid is not None:
                 self._session_expire = False

--- a/synology_api/photos.py
+++ b/synology_api/photos.py
@@ -54,12 +54,11 @@ class Photos:
 
         return self.request_data(api_name, api_path, req_param)
 
-
     def count_folders(self, folder_id=0):
-        return self._count_folders(folder_id, 'SYNO.FotoBrowse.Folder')
+        return self._count_folders(folder_id, 'SYNO.Foto.Browse.Folder')
 
-    def count_team_folders(self, fodler_id=0):
-        return self._count_folders(folder_id, 'SYNO.FotoTeam.FotoBrowse.Folder')
+    def count_team_folders(self, folder_id=0):
+        return self._count_folders(folder_id, 'SYNO.FotoTeam.Browse.Folder')
 
     def _count_folders(self, folder_id, api_name):
         info = self.photos_list[api_name]

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+credentials.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,24 @@
+
+# Testing
+
+In order to be able to run a test against a local Synology device, create a file
+_credentials.yaml_ in this folder with the following content:
+
+```json
+{
+  "device": "<your_device_name>",
+  "<your_device_name>": {
+    "ip_address": "<your_ip_address>",
+    "port": <your_port>,
+    "username": "<your_user>",
+    "password": "<your_password>",
+    "secure": true,
+    "cert_verify": false,
+    "dsm_version": 7,
+    "otp_code": null
+  }
+}
+```
+
+The file is read by _fixtures.py_ and can be fed to the constructor of a Synology
+Service. Switch to a different device by setting the name in the _device_ key.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,18 @@
+
+from importlib.resources import path
+from json import loads as load_json
+from pathlib import Path
+from typing import Dict
+
+from pytest import fixture
+
+CREDENTIALS_FILE = 'credentials.json'
+
+with path( 'tests', '__init__.py' ) as p:
+	credentials_path = Path( p.parent, CREDENTIALS_FILE )
+	credentials = load_json( credentials_path.read_text( 'UTF-8' ) )
+	DEVICE = credentials.get( credentials.get( 'device' ) )
+
+@fixture
+def device() -> Dict:
+	return DEVICE

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,6 +6,8 @@ from typing import Dict
 
 from pytest import fixture
 
+from synology_api.photos import Photos
+
 CREDENTIALS_FILE = 'credentials.json'
 
 with path( 'tests', '__init__.py' ) as p:
@@ -16,3 +18,7 @@ with path( 'tests', '__init__.py' ) as p:
 @fixture
 def device() -> Dict:
 	return DEVICE
+
+@fixture
+def photos( device ) -> Photos:
+	return Photos( **device )

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -4,7 +4,22 @@ from typing import Mapping
 from synology_api.photos import Photos
 
 from .fixtures import device
+from .fixtures import photos
 
 def test_login( device: Mapping ):
 	photos = Photos( **device )
 	assert photos.get_userinfo() is not None and photos.get_userinfo().get( 'success' )
+
+def test_count_folders( photos: Photos ):
+	# find 'root' folder first
+	parent_id = 0
+	response = photos.list_folders( 0 )
+	if 'data' in response and response.get( 'success', False ):
+		for item in response.get( 'data' ).get( 'list', [] ):
+			parent_id = item['parent']
+			break
+
+	assert parent_id > 0
+
+	response = photos.count_folders( parent_id )
+	assert 'data' in response and response.get( 'success' )

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -1,0 +1,10 @@
+
+from typing import Mapping
+
+from synology_api.photos import Photos
+
+from .fixtures import device
+
+def test_login( device: Mapping ):
+	photos = Photos( **device )
+	assert photos.get_userinfo() is not None and photos.get_userinfo().get( 'success' )


### PR DESCRIPTION
Please verify fix on your device. At least on my NAS, running DSM 7.0, a login was not possible. It worked only after removing the session key from the params dict. Not sure if this happens also when trying to login to other Synology services. Tried with FileStation and it worked with the session key being present.