### PR TITLE
Error codes

### DIFF
--- a/synology_api/audiostation.py
+++ b/synology_api/audiostation.py
@@ -6,10 +6,7 @@ class AudioStation:
     def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
         self.session = syn.Authentication(ip_address, port, username, password, secure,  cert_verify, dsm_version, debug, otp_code)
 
-        if debug is True:
-            print(self.session.login('AudioStation'))
-        else:
-            self.session.login('AudioStation')
+        self.session.login('AudioStation')
         self.session.get_api_list('AudioStation')
 
         self.request_data = self.session.request_data

--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -1,6 +1,5 @@
 import requests
-from .error_codes import error_code_msg
-from .error_codes import CODE_SUCCESS
+from .error_codes import error_codes, CODE_SUCCESS, CODE_UNKNOWN
 from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
 
@@ -39,33 +38,35 @@ class Authentication:
         if not self._session_expire and self._sid is not None:
             self._session_expire = False
             if self._debug is True:
-                return CODE_SUCCESS, 'User already logged'
+                print('User already logged in')
         else:
             session_request = requests.get(self._base_url + login_api, params, verify=self._verify)
             session_request_json = session_request.json()
-            error_code, error_msg = error_code_msg(session_request_json)
+            error_code = self._get_error_code(session_request_json)
             if not error_code:
-                self._sid = session_request.json()['data']['sid']
+                self._sid = session_request_json['data']['sid']
                 self._session_expire = False
                 if self._debug is True:
-                    return 'User logging... New session started!'
-            return error_code, error_msg
+                    print('User logged in, new session started!')
+            else:
+                self._sid = None
+                if self._debug is True:
+                    print('Login failed: ' + self._get_error_message(error_code))
 
     def logout(self, application):
         logout_api = 'auth.cgi?api=SYNO.API.Auth'
-        param = {'version': '2', 'method': 'logout', 'session': application}
+        param = {'version': self._version, 'method': 'logout', 'session': application}
 
         response = requests.get(self._base_url + logout_api, param, verify=self._verify)
-        if response.json()['success'] is True:
-            self._session_expire = True
-            self._sid = None
-            if self._debug is True:
-                return 'Logged out'
+        error_code = self._get_error_code(response.json())
+        self._session_expire = True
+        self._sid = None
+        if self._debug is True:
+            if not error_code:
+                print('Successfully logged out.')
         else:
-            self._session_expire = True
-            self._sid = None
             if self._debug is True:
-                return 'No valid session is open'
+                print('Logout failed: ' + self._get_error_message(error_code))
 
     def get_api_list(self, app=None):
         query_path = 'query.cgi?api=SYNO.API.Info'
@@ -121,23 +122,34 @@ class Authentication:
 
         req_param['_sid'] = self._sid
 
+        url = ('%s%s' % (self._base_url, api_path)) + '?api=' + api_name
+
         if method == 'get':
-            url = ('%s%s' % (self._base_url, api_path)) + '?api=' + api_name
             response = requests.get(url, req_param, verify=self._verify)
-
-            if response_json is True:
-                return response.json()
-            else:
-                return response
-
         elif method == 'post':
-            url = ('%s%s' % (self._base_url, api_path)) + '?api=' + api_name
             response = requests.post(url, req_param, verify=self._verify)
 
-            if response_json is True:
-                return response.json()
-            else:
-                return response
+        error_code = self._get_error_code(response.json())
+
+        if error_code:
+            if self._debug is True:
+                print('Data request failed: ' + self._get_error_message(error_code))
+
+        if response_json is True:
+            return response.json()
+        else:
+            return response
+
+    def _get_error_code(self, response: dict):
+        if response.get('success'):
+            code = CODE_SUCCESS
+        else:
+            code = response.get('error').get('code')
+        return code
+
+    def _get_error_message(self, code: int) -> str:
+        message = error_codes.get(code, CODE_UNKNOWN)
+        return 'Error {} - {}'.format(code, message)
 
     @property
     def sid(self):

--- a/synology_api/base_api_core.py
+++ b/synology_api/base_api_core.py
@@ -5,10 +5,7 @@ class Core(object):
     def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
 
         self.session = syn.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
-        if debug is True:
-            print(self.session.login('Core'))
-        else:
-            self.session.login('Core')
+        self.session.login('Core')
         self.session.get_api_list('Core')
         self.session.get_api_list()
 

--- a/synology_api/downloadstation.py
+++ b/synology_api/downloadstation.py
@@ -8,10 +8,7 @@ class DownloadStation:
         self.session = syn.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
         self._bt_search_id = ''
         self._bt_search_id_list = []
-        if debug is True:
-            print(self.session.login('DownloadStation'))
-        else:
-            self.session.login('DownloadStation')
+        self.session.login('DownloadStation')
         self.session.get_api_list('DownloadStation')
 
         self.request_data = self.session.request_data

--- a/synology_api/error_codes.py
+++ b/synology_api/error_codes.py
@@ -1,11 +1,9 @@
 # source: pages 8 and 16 on PDF:
 # https://global.download.synology.com/download/Document/Software/DeveloperGuide/Os/DSM/All/enu/DSM_Login_Web_API_Guide_enu.pdf
-from typing import Dict, Tuple
-
 CODE_SUCCESS = 0
 CODE_UNKNOWN = 9999
 
-errorcodes = {
+error_codes = {
     CODE_SUCCESS: 'Success',
     100: 'Unknown error',
     101: 'No parameter of API, method or version',
@@ -71,18 +69,3 @@ errorcodes = {
     410: 'Password must be changed',
     CODE_UNKNOWN: 'Unknown Error',
 }
-
-
-def get_error_msg(error_code: int) -> str:
-    if error_code in errorcodes.keys():
-        return errorcodes.get(error_code)
-    else:
-        return errorcodes.get(CODE_UNKNOWN)
-
-
-def error_code_msg(response_json: Dict) -> Tuple[int, str]:
-    if not response_json.get('success'):
-        errorcode = response_json.get('error').get('code')
-        return errorcode, get_error_msg(errorcode)
-    else:
-        return CODE_SUCCESS, get_error_msg(CODE_SUCCESS)

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -30,10 +30,8 @@ class FileStation:
         self._compress_taskid = ''
         self._compress_taskid_list = []
         self.request_data = self.session.request_data
-        if debug is True:
-            print(self.session.login('FileStation'))
-        else:
-            self.session.login('FileStation')
+        
+        self.session.login('FileStation')
         self.session.get_api_list('FileStation')
 
         self.file_station_list = self.session.app_api_list

--- a/synology_api/photos.py
+++ b/synology_api/photos.py
@@ -7,10 +7,7 @@ class Photos:
     def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
         self.session = syn.Authentication(ip_address, port, username, password, secure,  cert_verify, dsm_version, debug, otp_code)
 
-        if debug is True:
-            print(self.session.login('Foto'))
-        else:
-            self.session.login('Foto')
+        self.session.login('Foto')
         self.session.get_api_list('Foto')
 
         self.request_data = self.session.request_data

--- a/synology_api/universal_search.py
+++ b/synology_api/universal_search.py
@@ -5,10 +5,7 @@ from urllib import parse
 class UniversalSearch:
 	def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
 		self.session = auth.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
-		if debug is True:
-			print(self.session.logout('Finder'))
-		else:
-			self.session.login('Finder')
+		self.session.login('Finder')
 		self.session.get_api_list('Finder')
 		self.request_data = self.session.request_data
 		self.finder_list = self.session.app_api_list

--- a/synology_api/virtualization.py
+++ b/synology_api/virtualization.py
@@ -17,10 +17,7 @@ class Virtualization:
         self._vm_guest_name_list = []
         self._vm_created_taskid_list = []
 
-        if debug is True:
-            print(self.session.login('Virtualization'))
-        else:
-            self.session.login('Virtualization')
+        self.session.login('Virtualization')
         self.session.get_api_list('Virtualization')
 
         self.file_station_list = self.session.app_api_list


### PR DESCRIPTION
I reworked the authentication structure, stream lined some duplicate code and added also a error code check for `request_data()`

In general I don't think `login()` has to return something which is then checked for debug in every station API just to print that, but in that case `login()` can just directly print if debug is active