### PR TITLE
Add typing for api

### DIFF
--- a/synology_api/audiostation.py
+++ b/synology_api/audiostation.py
@@ -3,7 +3,10 @@ from . import auth as syn
 
 class AudioStation:
 
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
         self.session = syn.Authentication(ip_address, port, username, password, secure,  cert_verify, dsm_version, debug, otp_code)
 
         self.session.login('AudioStation')

--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -1,5 +1,6 @@
 import requests
 from .error_codes import error_codes, CODE_SUCCESS, CODE_UNKNOWN
+from typing import Union
 from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
 
@@ -28,10 +29,10 @@ class Authentication:
         self.full_api_list = {}
         self.app_api_list = {}
 
-    def verify_cert_enabled(self):
+    def verify_cert_enabled(self) -> bool:
         return self._verify
 
-    def login(self, application: str):
+    def login(self, application: str) -> None:
         login_api = 'auth.cgi?api=SYNO.API.Auth'
         params = {'version': self._version, 'method': 'login', 'account': self._username,
                   'passwd': self._password, 'session': application, 'format': 'cookie'}
@@ -56,7 +57,7 @@ class Authentication:
                 if self._debug is True:
                     print('Login failed: ' + self._get_error_message(error_code))
 
-    def logout(self, application: str):
+    def logout(self, application: str) -> None:
         logout_api = 'auth.cgi?api=SYNO.API.Auth'
         param = {'version': self._version, 'method': 'logout', 'session': application}
 
@@ -70,7 +71,7 @@ class Authentication:
             else:
                 print('Logout failed: ' + self._get_error_message(error_code))
 
-    def get_api_list(self, app: str = None):
+    def get_api_list(self, app: str = None) -> None:
         query_path = 'query.cgi?api=SYNO.API.Info'
         list_query = {'version': '1', 'method': 'query', 'query': 'all'}
 
@@ -85,7 +86,7 @@ class Authentication:
 
         return
 
-    def show_api_name_list(self):
+    def show_api_name_list(self) -> None:
         prev_key = ''
         for key in self.full_api_list:
             if key != prev_key:
@@ -93,7 +94,7 @@ class Authentication:
                 prev_key = key
         return
 
-    def show_json_response_type(self):
+    def show_json_response_type(self) -> None:
         for key in self.full_api_list:
             for sub_key in self.full_api_list[key]:
                 if sub_key == 'requestFormat':
@@ -101,7 +102,7 @@ class Authentication:
                         print(key + '   Returns JSON data')
         return
 
-    def search_by_app(self, app: str):
+    def search_by_app(self, app: str) -> None:
         print_check = 0
         for key in self.full_api_list:
             if app.lower() in key.lower():
@@ -113,7 +114,7 @@ class Authentication:
         return
 
     def request_data(self, api_name: str, api_path: str, 
-                     req_param: dict, method: str = None, response_json=True):  # 'post' or 'get'
+                     req_param: dict, method: str = None, response_json=True) -> Union[str, dict]:  # 'post' or 'get'
 
         # Convert all boolean in string in lowercase because Synology API is waiting for "true" or "false"
         for k, v in req_param.items():
@@ -144,7 +145,7 @@ class Authentication:
             return response
 
     @staticmethod
-    def _get_error_code(response: dict):
+    def _get_error_code(response: dict) -> str:
         if response.get('success'):
             code = CODE_SUCCESS
         else:
@@ -157,9 +158,9 @@ class Authentication:
         return 'Error {} - {}'.format(code, message)
 
     @property
-    def sid(self):
+    def sid(self) -> str:
         return self._sid
 
     @property
-    def base_url(self):
+    def base_url(self) -> str:
         return self._base_url

--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -5,8 +5,11 @@ from urllib3.exceptions import InsecureRequestWarning
 
 
 class Authentication:
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True,
-                 otp_code=None):
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True,
+                 otp_code: str = None):
         self._ip_address = ip_address
         self._port = port
         self._username = username
@@ -28,7 +31,7 @@ class Authentication:
     def verify_cert_enabled(self):
         return self._verify
 
-    def login(self, application):
+    def login(self, application: str):
         login_api = 'auth.cgi?api=SYNO.API.Auth'
         params = {'version': self._version, 'method': 'login', 'account': self._username,
                   'passwd': self._password, 'session': application, 'format': 'cookie'}
@@ -53,7 +56,7 @@ class Authentication:
                 if self._debug is True:
                     print('Login failed: ' + self._get_error_message(error_code))
 
-    def logout(self, application):
+    def logout(self, application: str):
         logout_api = 'auth.cgi?api=SYNO.API.Auth'
         param = {'version': self._version, 'method': 'logout', 'session': application}
 
@@ -67,7 +70,7 @@ class Authentication:
             else:
                 print('Logout failed: ' + self._get_error_message(error_code))
 
-    def get_api_list(self, app=None):
+    def get_api_list(self, app: str = None):
         query_path = 'query.cgi?api=SYNO.API.Info'
         list_query = {'version': '1', 'method': 'query', 'query': 'all'}
 
@@ -98,7 +101,7 @@ class Authentication:
                         print(key + '   Returns JSON data')
         return
 
-    def search_by_app(self, app):
+    def search_by_app(self, app: str):
         print_check = 0
         for key in self.full_api_list:
             if app.lower() in key.lower():
@@ -109,7 +112,8 @@ class Authentication:
             print('Not Found')
         return
 
-    def request_data(self, api_name, api_path, req_param, method=None, response_json=True):  # 'post' or 'get'
+    def request_data(self, api_name: str, api_path: str, 
+                     req_param: dict, method: str = None, response_json=True):  # 'post' or 'get'
 
         # Convert all boolean in string in lowercase because Synology API is waiting for "true" or "false"
         for k, v in req_param.items():
@@ -121,7 +125,7 @@ class Authentication:
 
         req_param['_sid'] = self._sid
 
-        url = ('%s%s' % (self._base_url, api_path)) + '?api=' + api_name
+        url = f"{self._base_url}{api_path}?api={api_name}"
 
         if method == 'get':
             response = requests.get(url, req_param, verify=self._verify)

--- a/synology_api/base_api_core.py
+++ b/synology_api/base_api_core.py
@@ -2,7 +2,10 @@ from . import auth as syn
 
 
 class Core(object):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
 
         self.session = syn.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
         self.session.login('Core')

--- a/synology_api/core_active_backup.py
+++ b/synology_api/core_active_backup.py
@@ -4,8 +4,11 @@ import time
 
 
 class ActiveBackupBusiness(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(ActiveBackupBusiness, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def list_vm_hypervisor(self):
         api_name = 'SYNO.ActiveBackup.Inventory'

--- a/synology_api/core_backup.py
+++ b/synology_api/core_backup.py
@@ -2,8 +2,11 @@ from . import base_api_core
 
 
 class Backup(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(Backup, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def backup_repository_get(self, taskid):
         api_name = 'SYNO.Backup.Repository'

--- a/synology_api/core_certificate.py
+++ b/synology_api/core_certificate.py
@@ -9,8 +9,11 @@ import json
 
 
 class Certificate(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(Certificate, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
         self._debug = debug
 
     def _base_certificate_methods(self, method, cert_id=None, ids=None):

--- a/synology_api/core_sys_info.py
+++ b/synology_api/core_sys_info.py
@@ -2,8 +2,11 @@ from . import base_api_core
 
 
 class SysInfo(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(SysInfo, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def fileserv_smb(self):
         api_name = 'SYNO.Core.FileServ.SMB'

--- a/synology_api/dhcp_server.py
+++ b/synology_api/dhcp_server.py
@@ -2,8 +2,11 @@ from . import base_api_core
 
 
 class DhcpServer(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(DhcpServer, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def general_info(self):
         api_name = 'SYNO.Network.DHCPServer'

--- a/synology_api/directory_server.py
+++ b/synology_api/directory_server.py
@@ -32,8 +32,11 @@ class DirectoryServer(base_api_core.Core):
     - Perform an entry request to complete a Deletion
     """
 
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(DirectoryServer, self).__init__(ip_address, port,
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port,
                                               username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def get_directory_info(self):

--- a/synology_api/docker_api.py
+++ b/synology_api/docker_api.py
@@ -2,9 +2,11 @@ from . import base_api_core
 
 
 class Docker(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7,
-                 debug=True, otp_code=None):
-        super(Docker, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def containers(self):
         api_name = 'SYNO.Docker.Container'

--- a/synology_api/downloadstation.py
+++ b/synology_api/downloadstation.py
@@ -3,7 +3,11 @@ from . import auth as syn
 
 class DownloadStation:
 
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None, interactive_output=True):
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None,
+                 interactive_output: bool = True):
 
         self.session = syn.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
         self._bt_search_id = ''

--- a/synology_api/drive_admin_console.py
+++ b/synology_api/drive_admin_console.py
@@ -2,9 +2,11 @@ from . import base_api_core
 
 
 class AdminConsole(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7,
-                 debug=True, otp_code=None):
-        super(AdminConsole, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def status_info(self):
         api_name = 'SYNO.SynologyDrive'

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -1,6 +1,7 @@
 import os
 import time
 from datetime import datetime
+from os import PathLike
 
 import requests
 import sys
@@ -11,7 +12,12 @@ from . import auth as syn
 
 class FileStation:
 
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None, interactive_output=True):
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, 
+                 otp_code: str = None, 
+                 interactive_output=True):
 
         self.session = syn.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
@@ -74,8 +80,8 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_file_list(self, folder_path=None, offset=None, limit=None, sort_by=None,
-                      sort_direction=None, pattern=None, filetype=None, goto_path=None, additional=None):
+    def get_file_list(self, folder_path: PathLike = None, offset=None, limit=None, sort_by=None,
+                      sort_direction=None, pattern=None, filetype=None, goto_path: PathLike = None, additional=None):
 
         api_name = 'SYNO.FileStation.List'
         info = self.file_station_list[api_name]
@@ -103,7 +109,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_file_info(self, path=None, additional=None):
+    def get_file_info(self, path: PathLike = None, additional=None):
         api_name = 'SYNO.FileStation.List'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -131,7 +137,7 @@ class FileStation:
     # TODO  all working if specify extension check if correct [pattern, extension]
     #  it works if you put extension='...'
 
-    def search_start(self, folder_path=None, recursive=None, pattern=None, extension=None, filetype=None,
+    def search_start(self, folder_path: PathLike = None, recursive=None, pattern=None, extension=None, filetype=None,
                      size_from=None, size_to=None, mtime_from=None, mtime_to=None, crtime_from=None, crtime_to=None,
                      atime_from=None, atime_to=None, owner=None, group=None):
 
@@ -210,7 +216,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def stop_search_task(self, taskid=None):
+    def stop_search_task(self, taskid: str = None):
         api_name = 'SYNO.FileStation.Search'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -288,7 +294,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def add_a_favorite(self, path=None, name=None, index=None):
+    def add_a_favorite(self, path: PathLike = None, name=None, index=None):
         api_name = 'SYNO.FileStation.Favorite'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -304,7 +310,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def delete_a_favorite(self, path=None):
+    def delete_a_favorite(self, path: PathLike = None):
         api_name = 'SYNO.FileStation.Favorite'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -325,7 +331,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def edit_favorite_name(self, path=None, new_name=None):
+    def edit_favorite_name(self, path: PathLike = None, new_name=None):
         api_name = 'SYNO.FileStation.Favorite'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -343,7 +349,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def replace_all_favorite(self, path=None, name=None):
+    def replace_all_favorite(self, path: PathLike = None, name=None):
         api_name = 'SYNO.FileStation.Favorite'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -367,7 +373,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def start_dir_size_calc(self, path=None):
+    def start_dir_size_calc(self, path: PathLike = None):
         api_name = 'SYNO.FileStation.DirSize'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -401,7 +407,7 @@ class FileStation:
         return output
 
 
-    def stop_dir_size_calc(self, taskid=None):
+    def stop_dir_size_calc(self, taskid: str = None):
         api_name = 'SYNO.FileStation.DirSize'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -417,7 +423,7 @@ class FileStation:
 
         return 'The task has been stopped'
 
-    def get_dir_status(self, taskid=None):
+    def get_dir_status(self, taskid: str = None):
         api_name = 'SYNO.FileStation.DirSize'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -428,7 +434,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def start_md5_calc(self, file_path=None):
+    def start_md5_calc(self, file_path: PathLike = None):
         api_name = 'SYNO.FileStation.MD5'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -451,7 +457,7 @@ class FileStation:
 
         return output
 
-    def get_md5_status(self, taskid=None):
+    def get_md5_status(self, taskid: str = None):
         api_name = 'SYNO.FileStation.MD5'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -466,7 +472,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def stop_md5_calc(self, taskid=None):
+    def stop_md5_calc(self, taskid: str = None):
         api_name = 'SYNO.FileStation.DirSize'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -482,7 +488,7 @@ class FileStation:
 
         return 'The task has been stopped'
 
-    def check_permissions(self, path=None, filename=None, overwrite=None, create_only=None):
+    def check_permissions(self, path: PathLike = None, filename=None, overwrite=None, create_only=None):
         api_name = 'SYNO.FileStation.CheckPermission'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -555,7 +561,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def create_sharing_link(self, path=None, password=None, date_expired=None,
+    def create_sharing_link(self, path: PathLike = None, password=None, date_expired=None,
                             date_available=None, expire_times=0):
         api_name = 'SYNO.FileStation.Sharing'
         info = self.file_station_list[api_name]
@@ -612,7 +618,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def create_folder(self, folder_path=None, name=None, force_parent=None, additional=None):
+    def create_folder(self, folder_path: PathLike = None, name=None, force_parent=None, additional=None):
         api_name = 'SYNO.FileStation.CreateFolder'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -655,7 +661,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def rename_folder(self, path=None, name=None, additional=None, search_taskid=None):
+    def rename_folder(self, path: PathLike = None, name=None, additional=None, search_taskid: str = None):
         api_name = 'SYNO.FileStation.Rename'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -696,8 +702,8 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def start_copy_move(self, path=None, dest_folder_path=None, overwrite=None, remove_src=None,
-                        accurate_progress=None, search_taskid=None):
+    def start_copy_move(self, path: PathLike = None, dest_folder_path: PathLike = None, overwrite=None, remove_src=None,
+                        accurate_progress=None, search_taskid: str = None):
         api_name = 'SYNO.FileStation.CopyMove'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -745,7 +751,7 @@ class FileStation:
         return output
 
 
-    def get_copy_move_status(self, taskid=None):
+    def get_copy_move_status(self, taskid: str = None):
         api_name = 'SYNO.FileStation.CopyMove'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -758,7 +764,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def stop_copy_move_task(self, taskid=None):
+    def stop_copy_move_task(self, taskid: str = None):
         api_name = 'SYNO.FileStation.CopyMove'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -773,7 +779,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def start_delete_task(self, path=None, accurate_progress=None, recursive=None, search_taskid=None):
+    def start_delete_task(self, path: PathLike = None, accurate_progress=None, recursive=None, search_taskid: str = None):
         api_name = 'SYNO.FileStation.Delete'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -809,7 +815,7 @@ class FileStation:
         return output
 
 
-    def get_delete_status(self, taskid=None):
+    def get_delete_status(self, taskid: str = None):
         api_name = 'SYNO.FileStation.Delete'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -822,7 +828,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def stop_delete_task(self, taskid=None):
+    def stop_delete_task(self, taskid: str = None):
         api_name = 'SYNO.FileStation.Delete'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -837,7 +843,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def delete_blocking_function(self, path=None, recursive=None, search_taskid=None):
+    def delete_blocking_function(self, path: PathLike = None, recursive=None, search_taskid: str = None):
         api_name = 'SYNO.FileStation.Delete'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -863,7 +869,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def start_extract_task(self, file_path=None, dest_folder_path=None, overwrite=None, keep_dir=None,
+    def start_extract_task(self, file_path: PathLike = None, dest_folder_path: PathLike = None, overwrite=None, keep_dir=None,
                            create_subfolder=None, codepage=None, password=None, item_id=None):
         api_name = 'SYNO.FileStation.Extract'
         info = self.file_station_list[api_name]
@@ -895,7 +901,7 @@ class FileStation:
 
         return output
 
-    def get_extract_status(self, taskid=None):
+    def get_extract_status(self, taskid: str = None):
         api_name = 'SYNO.FileStation.Extract'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -908,7 +914,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def stop_extract_task(self, taskid=None):
+    def stop_extract_task(self, taskid: str = None):
         api_name = 'SYNO.FileStation.Extract'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -923,7 +929,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_file_list_of_archive(self, file_path=None, offset=None, limit=None, sort_by=None,
+    def get_file_list_of_archive(self, file_path: PathLike = None, offset=None, limit=None, sort_by=None,
                                  sort_direction=None, codepage=None, password=None, item_id=None):
         api_name = 'SYNO.FileStation.Extract'
         info = self.file_station_list[api_name]
@@ -940,7 +946,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def start_file_compression(self, path=None, dest_file_path=None, level=None, mode=None,
+    def start_file_compression(self, path: PathLike = None, dest_file_path: PathLike = None, level=None, mode=None,
                                compress_format=None, password=None):
         api_name = 'SYNO.FileStation.Compress'
         info = self.file_station_list[api_name]
@@ -986,7 +992,7 @@ class FileStation:
         return output
 
 
-    def get_compress_status(self, taskid=None):
+    def get_compress_status(self, taskid: str = None):
         api_name = 'SYNO.FileStation.Compress'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -999,7 +1005,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def stop_compress_task(self, taskid=None):
+    def stop_compress_task(self, taskid: str = None):
         api_name = 'SYNO.FileStation.Compress'
         info = self.file_station_list[api_name]
         api_path = info['path']
@@ -1033,7 +1039,7 @@ class FileStation:
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_file(self, path=None, mode=None, dest_path=".", chunk_size=8192, verify=False):
+    def get_file(self, path: PathLike = None, mode=None, dest_path: PathLike = ".", chunk_size=8192, verify=False):
 
         api_name = 'SYNO.FileStation.Download'
         info = self.file_station_list[api_name]

--- a/synology_api/log_center.py
+++ b/synology_api/log_center.py
@@ -2,9 +2,11 @@ from . import base_api_core
 
 
 class LogCenter(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7,
-                 debug=True, otp_code=None):
-        super(LogCenter, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def logcenter(self):
         api_name = 'SYNO.LogCenter.RecvRule'

--- a/synology_api/notestation.py
+++ b/synology_api/notestation.py
@@ -2,9 +2,11 @@ from . import base_api_core
 
 
 class NoteStation(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7,
-                 debug=True, otp_code=None):
-        super(NoteStation, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def settings_info(self):
         api_name = 'SYNO.NoteStation.Setting'

--- a/synology_api/oauth.py
+++ b/synology_api/oauth.py
@@ -2,8 +2,11 @@ from . import base_api_core
 
 
 class OAuth(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(OAuth, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def clients(self, offset=0, limit=20):
         api_name = 'SYNO.OAUTH.Client'

--- a/synology_api/photos.py
+++ b/synology_api/photos.py
@@ -4,7 +4,10 @@ import json
 
 class Photos:
 
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
         self.session = syn.Authentication(ip_address, port, username, password, secure,  cert_verify, dsm_version, debug, otp_code)
 
         self.session.login('Foto')

--- a/synology_api/security_advisor.py
+++ b/synology_api/security_advisor.py
@@ -2,8 +2,11 @@ from . import base_api_core
 
 
 class SecurityAdvisor(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(SecurityAdvisor, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code=None)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code=None)
 
     def general_info(self):
         api_name = 'SYNO.SecurityAdvisor.Conf.Location'

--- a/synology_api/universal_search.py
+++ b/synology_api/universal_search.py
@@ -3,41 +3,44 @@ from urllib import parse
 
 
 class UniversalSearch:
-	def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-		self.session = auth.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
-		self.session.login('Finder')
-		self.session.get_api_list('Finder')
-		self.request_data = self.session.request_data
-		self.finder_list = self.session.app_api_list
-		self._sid = self.session.sid
-		self.base_url = self.session.base_url
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        self.session = auth.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+        self.session.login('Finder')
+        self.session.get_api_list('Finder')
+        self.request_data = self.session.request_data
+        self.finder_list = self.session.app_api_list
+        self._sid = self.session.sid
+        self.base_url = self.session.base_url
 
-	def logout(self):
-		self.session.logout('FileStation')
+    def logout(self):
+        self.session.logout('FileStation')
 
-	def search(self, keyword):
-		api_name = 'SYNO.Finder.FileIndexing.Search'
-		info = self.finder_list[api_name]
-		api_path = info['path']
+    def search(self, keyword):
+        api_name = 'SYNO.Finder.FileIndexing.Search'
+        info = self.finder_list[api_name]
+        api_path = info['path']
 
-		req_param = {
-			"query_serial": 1,
-			"indice": '[]',
-			"keyword": keyword,
-			"orig_keyword": keyword,
-			"criteria_list": '[]',
-			"from": 0,
-			"size": 10,
-			"fields": '["SYNOMDAcquisitionMake","SYNOMDAcquisitionModel","SYNOMDAlbum","SYNOMDAperture","SYNOMDAudioBitRate","SYNOMDAudioTrackNumber","SYNOMDAuthors","SYNOMDCodecs","SYNOMDContentCreationDate","SYNOMDContentModificationDate","SYNOMDCreator","SYNOMDDurationSecond","SYNOMDExposureTimeString","SYNOMDExtension","SYNOMDFSCreationDate","SYNOMDFSName","SYNOMDFSSize","SYNOMDISOSpeed","SYNOMDLastUsedDate","SYNOMDMediaTypes","SYNOMDMusicalGenre","SYNOMDOwnerUserID","SYNOMDOwnerUserName","SYNOMDRecordingYear","SYNOMDResolutionHeightDPI","SYNOMDResolutionWidthDPI","SYNOMDTitle","SYNOMDVideoBitRate","SYNOMDIsEncrypted"]',
-			"file_type": "",
-			"search_weight_list": '[{"field":"SYNOMDWildcard","weight":1},{"field":"SYNOMDTextContent","weight":1},{"field":"SYNOMDSearchFileName","weight":8.5,"trailing_wildcard":"true"}]',
-			"sorter_field": "relevance",
-			"sorter_direction": "asc",
-			"sorter_use_nature_sort": "false",
-			"sorter_show_directory_first": "true",
-			"api": "SYNO.Finder.FileIndexing.Search",
-			"method": "search",
-			"version": 1
-		}
+        req_param = {
+        	"query_serial": 1,
+        	"indice": '[]',
+        	"keyword": keyword,
+        	"orig_keyword": keyword,
+        	"criteria_list": '[]',
+        	"from": 0,
+        	"size": 10,
+        	"fields": '["SYNOMDAcquisitionMake","SYNOMDAcquisitionModel","SYNOMDAlbum","SYNOMDAperture","SYNOMDAudioBitRate","SYNOMDAudioTrackNumber","SYNOMDAuthors","SYNOMDCodecs","SYNOMDContentCreationDate","SYNOMDContentModificationDate","SYNOMDCreator","SYNOMDDurationSecond","SYNOMDExposureTimeString","SYNOMDExtension","SYNOMDFSCreationDate","SYNOMDFSName","SYNOMDFSSize","SYNOMDISOSpeed","SYNOMDLastUsedDate","SYNOMDMediaTypes","SYNOMDMusicalGenre","SYNOMDOwnerUserID","SYNOMDOwnerUserName","SYNOMDRecordingYear","SYNOMDResolutionHeightDPI","SYNOMDResolutionWidthDPI","SYNOMDTitle","SYNOMDVideoBitRate","SYNOMDIsEncrypted"]',
+        	"file_type": "",
+        	"search_weight_list": '[{"field":"SYNOMDWildcard","weight":1},{"field":"SYNOMDTextContent","weight":1},{"field":"SYNOMDSearchFileName","weight":8.5,"trailing_wildcard":"true"}]',
+        	"sorter_field": "relevance",
+        	"sorter_direction": "asc",
+        	"sorter_use_nature_sort": "false",
+        	"sorter_show_directory_first": "true",
+        	"api": "SYNO.Finder.FileIndexing.Search",
+        	"method": "search",
+        	"version": 1
+        }
 
-		return self.request_data(api_name, api_path, req_param)
+        return self.request_data(api_name, api_path, req_param)

--- a/synology_api/usb_copy.py
+++ b/synology_api/usb_copy.py
@@ -2,8 +2,11 @@ from . import base_api_core
 
 
 class USBCopy(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
-        super(USBCopy, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def usb_copy_info(self, id=1):
         api_name = 'SYNO.USBCopy'

--- a/synology_api/virtualization.py
+++ b/synology_api/virtualization.py
@@ -3,7 +3,10 @@ from . import auth as syn
 
 class Virtualization:
 
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7, debug=True, otp_code=None):
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
 
         self.session = syn.Authentication(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 

--- a/synology_api/vpn.py
+++ b/synology_api/vpn.py
@@ -2,9 +2,11 @@ from . import base_api_core
 
 
 class VPN(base_api_core.Core):
-    def __init__(self, ip_address, port, username, password, secure=False, cert_verify=False, dsm_version=7,
-                 debug=True, otp_code=None):
-        super(VPN, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
+    def __init__(self, ip_address: str, port: int, 
+                 username: str, password: str, 
+                 secure=False, cert_verify=False, 
+                 dsm_version=7, debug=True, otp_code: str = None):
+        super().__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code)
 
     def settings_list(self):
         api_name = 'SYNO.VPNServer.Settings.Config'


### PR DESCRIPTION
add typing for auth.py
add
```

    def __init__(self, ip_address: str, port: int, 
                 username: str, password: str, 
                 secure=False, cert_verify=False, 
                 dsm_version=7, debug=True, otp_code: str = None):
```
for most api
add return type hint for `filestation`

and remove unessary `super(xxx, self)`