### PR TITLE
query_event_list_by_filter: rename camera id filtering parameter

### DIFF
--- a/synology_api/surveillancestation.py
+++ b/synology_api/surveillancestation.py
@@ -706,7 +706,7 @@ class SurveillanceStation(base_api.BaseApi):
     def query_event_list_by_filter(self,
                                    offset: int = None,
                                    limit: int = None,
-                                   cameraId: str = None,
+                                   cameraIds: str = None,
                                    fromTime: int = None,
                                    toTime: int = None,
                                    dsld: int = None,


### PR DESCRIPTION
Method optional parameter "cameraId" in method query_event_list_by_filter was renamed in "cameraIds" as expected by Synology APIs.
Code to test the change:
```
now = datetime.datetime.now()
today_midnight = datetime.datetime(now.year, now.month, now.day)

# not filtered by camera id
camera_events_response = ss.query_event_list_by_filter(limit=100, fromTime=int(today_midnight.timestamp()))
camera_events = camera_events_response['data']['recordings']
self.assertIsNotNone(camera_events )
self.assertEqual(events.__len__(), 100)

# filtered by camera id
camera_events_response = ss.query_event_list_by_filter(limit=100, cameraIds=camera_id,
                                                           fromTime=int(today_midnight .timestamp()))
camera_events = camera_events_response['data']['recordings']
self.assertIsNotNone(camera_events )
self.assertEqual(events.__len__(), 12)
```