### PR TITLE
Tests filestation api issue 159

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Test resources
+tests/resources/config-test.json

--- a/tests/resources/config-test-sample.json
+++ b/tests/resources/config-test-sample.json
@@ -1,0 +1,10 @@
+#### COPY THIS FILE AND NAME IT config-test.json AND REPLACE WITH YOUR VALUES
+{
+  "synology_ip": "your_dsm_ip",
+  "synology_port": your_dsm_port_as_int,
+  "synology_user": "your_dsm_user",
+  "synology_password": "your_dsm_password",
+  "synology_secure": true_if_your_dsm_http_endpoint_is_https,
+  "dsm_version": your_dsm_version_as_int,
+  "otp_code": "your_dsm_otp_code"_or_null
+}

--- a/tests/test_syno_api.py
+++ b/tests/test_syno_api.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from unittest import TestCase
-
+import unittest
 from synology_api.filestation import FileStation
 from synology_api.surveillancestation import SurveillanceStation
 
@@ -20,11 +20,11 @@ class TestSynoApi(TestCase):
 
     def test_syno_filestation_login(self):
         fs = FileStation(ip_address=self.config["synology_ip"], port=self.config["synology_port"],
-                                      username=self.config["synology_user"],
-                                      password=self.config["synology_password"],
-                                      secure=bool(self.config["synology_secure"]), cert_verify=False,
-                                      dsm_version=int(self.config["dsm_version"]), debug=True,
-                                      otp_code=self.config["otp_code"])
+                         username=self.config["synology_user"],
+                         password=self.config["synology_password"],
+                         secure=bool(self.config["synology_secure"]), cert_verify=False,
+                         dsm_version=int(self.config["dsm_version"]), debug=True,
+                         otp_code=self.config["otp_code"])
 
         self.assertIsNotNone(fs)
         self.assertIsNotNone(fs.session)
@@ -36,11 +36,11 @@ class TestSynoApi(TestCase):
 
     def test_syno_surveillancestation_login(self):
         ss = SurveillanceStation(ip_address=self.config["synology_ip"], port=self.config["synology_port"],
-                                      username=self.config["synology_user"],
-                                      password=self.config["synology_password"],
-                                      secure=bool(self.config["synology_secure"]), cert_verify=False,
-                                      dsm_version=int(self.config["dsm_version"]), debug=True,
-                                      otp_code=self.config["otp_code"])
+                                 username=self.config["synology_user"],
+                                 password=self.config["synology_password"],
+                                 secure=bool(self.config["synology_secure"]), cert_verify=False,
+                                 dsm_version=int(self.config["dsm_version"]), debug=True,
+                                 otp_code=self.config["otp_code"])
 
         self.assertIsNotNone(ss)
         self.assertIsNotNone(ss.session)
@@ -51,3 +51,7 @@ class TestSynoApi(TestCase):
         ss_info_data = ss_info['data']
         self.assertIsNotNone(ss_info_data)
         self.assertEqual(ss_info_data['path'], '/webman/3rdparty/SurveillanceStation/')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_syno_api.py
+++ b/tests/test_syno_api.py
@@ -1,0 +1,53 @@
+import datetime
+import json
+from unittest import TestCase
+
+from synology_api.filestation import FileStation
+from synology_api.surveillancestation import SurveillanceStation
+
+
+def parse_config(config_path) -> dict[str, str]:
+    with open(config_path, 'r') as config_file:
+        config_data = json.load(config_file)
+    return config_data
+
+
+class TestSynoApi(TestCase):
+    config: dict[str, str]
+
+    def setUp(self):
+        self.config = parse_config('./resources/config-test.json')
+
+    def test_syno_filestation_login(self):
+        fs = FileStation(ip_address=self.config["synology_ip"], port=self.config["synology_port"],
+                                      username=self.config["synology_user"],
+                                      password=self.config["synology_password"],
+                                      secure=bool(self.config["synology_secure"]), cert_verify=False,
+                                      dsm_version=int(self.config["dsm_version"]), debug=True,
+                                      otp_code=self.config["otp_code"])
+
+        self.assertIsNotNone(fs)
+        self.assertIsNotNone(fs.session)
+        self.assertIsNotNone(fs.session.sid)
+        self.assertIsNot(fs.session.sid, '')
+        shares_list = fs.get_list_share()
+        self.assertIsNotNone(shares_list)
+        self.assertEqual(shares_list.__len__(), 2)
+
+    def test_syno_surveillancestation_login(self):
+        ss = SurveillanceStation(ip_address=self.config["synology_ip"], port=self.config["synology_port"],
+                                      username=self.config["synology_user"],
+                                      password=self.config["synology_password"],
+                                      secure=bool(self.config["synology_secure"]), cert_verify=False,
+                                      dsm_version=int(self.config["dsm_version"]), debug=True,
+                                      otp_code=self.config["otp_code"])
+
+        self.assertIsNotNone(ss)
+        self.assertIsNotNone(ss.session)
+        self.assertIsNotNone(ss.session.sid)
+        self.assertIsNot(ss.session.sid, '')
+        ss_info = ss.surveillance_station_info()
+        self.assertIsNotNone(ss_info)
+        ss_info_data = ss_info['data']
+        self.assertIsNotNone(ss_info_data)
+        self.assertEqual(ss_info_data['path'], '/webman/3rdparty/SurveillanceStation/')


### PR DESCRIPTION
Hi @N4S4,

to cover the login issues related to #159, I wrote a test class with a config file that could help to cover also the OTP use-case.

### config-tests.json examples
```
## no otp
{
  "synology_ip": "192.168.1.xyz",
  "synology_port": "5001",
  "synology_user": "user_without_otp",
  "synology_password": "password",
  "synology_secure": true,
  "dsm_version": 7,
  "otp_code": null
}

## otp
{
  "synology_ip": "192.168.1.xyz",
  "synology_port": "5001",
  "synology_user": "user_with_otp",
  "synology_password": "password",
  "synology_secure": true,
  "dsm_version": 7,
  "otp_code": "123456"
}
```
### from tests folder
> python -m unittest test_syno_api.py