### PR TITLE
FileStation application session name

### DIFF
--- a/synology_api/base_api.py
+++ b/synology_api/base_api.py
@@ -12,13 +12,15 @@ class BaseApi(object):
                  cert_verify: bool = False,
                  dsm_version: int = 7,
                  debug: bool = True,
-                 otp_code: Optional[str] = None
+                 otp_code: Optional[str] = None,
+                 application: str = 'Core',
                  ) -> None:
 
+        self.application = application
         self.session: syn.Authentication = syn.Authentication(ip_address, port, username, password, secure, cert_verify,
                                                               dsm_version, debug, otp_code)
-        self.session.login('Core')
-        self.session.get_api_list('Core')
+        self.session.login(self.application)
+        self.session.get_api_list(self.application)
         self.session.get_api_list()
 
         self.request_data: Any = self.session.request_data
@@ -28,5 +30,5 @@ class BaseApi(object):
         self.base_url: str = self.session.base_url
 
     def logout(self) -> None:
-        self.session.logout('Core')
+        self.session.logout(self.application)
         return

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -28,7 +28,7 @@ class FileStation(base_api.BaseApi):
                  ) -> None:
 
         super(FileStation, self).__init__(ip_address, port, username, password, secure, cert_verify,
-                                          dsm_version, debug, otp_code)
+                                          dsm_version, debug, otp_code, 'FileStation')
 
         self._dir_taskid: str = ''
         self._dir_taskid_list: list[str] = []


### PR DESCRIPTION
This changes base_api to allow 'session' to be arbitrarily set rather than hardcoded. Defaults to 'Core'.
i.e. FileStation API states that 'session' must be set as 'FileStation', which DSM 7.2.1-69057 appears to enforce.