### PR TITLE
Fixing req_params are not assigned properly

### DIFF
--- a/synology_api/photos.py
+++ b/synology_api/photos.py
@@ -264,9 +264,9 @@ class Photos(base_api.BaseApi):
         if type:
             req_param['type'] = type
         if passphrase:
-            req_param['passphrase']: passphrase
+            req_param['passphrase'] = passphrase
         if additional:
-            req_param['additional']: additional
+            req_param['additional'] = additional
 
         return self.request_data(api_name, api_path, req_param)
 


### PR DESCRIPTION
It seems that passphrase, additional are not assigned to req_param in photos.list_item_in_folders