### PR TITLE
Fixed #58

### DIFF
--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -671,6 +671,13 @@ class FileStation(base_api.BaseApi):
         api_path = info['path']
         req_param = {'version': info['maxVersion'], 'method': 'create'}
 
+        if date_expired:
+            if str(date_expired)[0] != '"':
+                date_expired = '"' + str(date_expired) + '"'
+        if date_available:
+            if str(date_available)[0] != '"':
+                date_available = '"' + str(date_available) + '"'
+
         for key, val in locals().items():
             if key not in ['self', 'api_name', 'info', 'api_path', 'req_param']:
                 if val is not None:
@@ -713,6 +720,13 @@ class FileStation(base_api.BaseApi):
         info = self.file_station_list[api_name]
         api_path = info['path']
         req_param = {'version': info['maxVersion'], 'method': 'edit'}
+
+        if date_expired:
+            if str(date_expired)[0] != '"':
+                date_expired = '"' + str(date_expired) + '"'
+        if date_available:
+            if str(date_available)[0] != '"':
+                date_available = '"' + str(date_available) + '"'
 
         if link_id is None:
             return 'Enter a valid id'


### PR DESCRIPTION
Fixed date_expired and date_available in create_sharing_link and edit_shared_link.
Synology needs double quotes in string for normal use.