### PR TITLE
fixed missing quoting of name of album to be created

### DIFF
--- a/synology_api/photos.py
+++ b/synology_api/photos.py
@@ -162,7 +162,7 @@ class Photos(base_api.BaseApi):
         api_name = 'SYNO.Foto.Browse.ConditionAlbum'
         info = self.photos_list[api_name]
         api_path = info['path']
-        req_param = {'version': info['maxVersion'], 'method': 'create', 'name': name,
+        req_param = {'version': info['maxVersion'], 'method': 'create', 'name': '"'+name+'"',
                      'condition': json.dumps(condition)}
 
         return self.request_data(api_name, api_path, req_param)


### PR DESCRIPTION
Currently, there is no quotation of the `name` parameter value when calling `SYNO.Foto.Browse.ConditionAlbum` with `method: create`. This leads to errors raised by the API as special characters are not properly interpreted as album name.