### PR TITLE
Added DSM v7 API Login option of device_id and device_name

### DIFF
--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -25,7 +25,9 @@ class Authentication:
                  cert_verify: bool = False,
                  dsm_version: int = 7,
                  debug: bool = True,
-                 otp_code: Optional[str] = None
+                 otp_code: Optional[str] = None,
+                 device_id: Optional[str] = None,
+                 device_name: Optional[str] = None
                  ) -> None:
 
         self._ip_address: str = ip_address
@@ -40,6 +42,8 @@ class Authentication:
         self._version: int = dsm_version
         self._debug: bool = debug
         self._otp_code: Optional[str] = otp_code
+        self._device_id: Optional[str] = device_id
+        self._device_name: Optional[str] = device_name
 
         if self._verify is False:
             disable_warnings(InsecureRequestWarning)
@@ -60,6 +64,11 @@ class Authentication:
                   'passwd': self._password, 'session': application, 'format': 'cookie', 'enable_syno_token':'yes'}
         if self._otp_code:
             params['otp_code'] = self._otp_code
+        if self._device_id is not None and self._device_name is not None:
+            params['device_id'] = self._device_id
+            params['device_name'] = self._device_name
+        if self._device_id is not None and self._device_name is None or self._device_id is None and self._device_name is not None:
+            print("device_id and device_name must be set together")
 
         if not self._session_expire and self._sid is not None:
             self._session_expire = False

--- a/synology_api/base_api.py
+++ b/synology_api/base_api.py
@@ -13,12 +13,14 @@ class BaseApi(object):
                  dsm_version: int = 7,
                  debug: bool = True,
                  otp_code: Optional[str] = None,
+                 device_id: Optional[str] = None,
+                 device_name: Optional[str] = None,
                  application: str = 'Core',
                  ) -> None:
 
         self.application = application
         self.session: syn.Authentication = syn.Authentication(ip_address, port, username, password, secure, cert_verify,
-                                                              dsm_version, debug, otp_code)
+                                                              dsm_version, debug, otp_code, device_id, device_name)
         self.session.login(self.application)
         self.session.get_api_list(self.application)
         self.session.get_api_list()

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -26,11 +26,13 @@ class FileStation(base_api.BaseApi):
                  dsm_version: int = 7,
                  debug: bool = True,
                  otp_code: Optional[str] = None,
+                 device_id: Optional[str] = None,
+                 device_name: Optional[str] = None,
                  interactive_output: bool = True
                  ) -> None:
 
         super(FileStation, self).__init__(ip_address, port, username, password, secure, cert_verify,
-                                          dsm_version, debug, otp_code, 'FileStation')
+                                          dsm_version, debug, otp_code, device_id, device_name, 'FileStation')
 
         self._dir_taskid: str = ''
         self._dir_taskid_list: list[str] = []

--- a/synology_api/photos.py
+++ b/synology_api/photos.py
@@ -15,11 +15,13 @@ class Photos(base_api.BaseApi):
                  cert_verify: bool = False,
                  dsm_version: int = 7,
                  debug: bool = True,
-                 otp_code: Optional[str] = None
+                 otp_code: Optional[str] = None,
+                 device_id: Optional[str] = None,
+                 device_name: Optional[str] = None
                  ) -> None:
 
         super(Photos, self).__init__(ip_address, port, username, password, secure, cert_verify,
-                                     dsm_version, debug, otp_code, 'FotoStation')
+                                     dsm_version, debug, otp_code, device_id, device_name, 'FotoStation')
 
         self.session.get_api_list('Foto')
 


### PR DESCRIPTION
As of DSMv7, there is the possibility to login by device_id and device_name expecially if you are scripting against the API with automated script execution in which case, you will not be able to provide an OTP code at the moment of execution.

The device_name needs to be manually registered first to get a generated device_id by the SynoNAS. This is not part of the script at all as it needs ot be done once by hand. See [DSM Login Web API Guide](https://global.download.synology.com/download/Document/Software/DeveloperGuide/Os/DSM/All/enu/DSM_Login_Web_API_Guide_enu.pdf#page=17&zoom=auto,-274,832)