### PR TITLE
feat: add asdf and go-task to repository

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -17,9 +17,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Get Node.js version from .tool-versions
+        id: node-version
+        run: echo "NODE_VERSION=$(cat .tool-versions | egrep nodejs | awk '{print $2}' | xargs)" >> $GITHUB_ENV
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: ./documentation/package-lock.json
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+nodejs 18.18.0
+python 3.9.6
+task 3.44.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,29 @@ As I say the following are just "guidelines" so do not feel obligated.
 
 Have a look on our Code of conduct!
 
+## How setup your environment
+
+If you want to contribute to this package, you may want to setup your environment.
+
+Install dependencies for your OS:
+```bash
+# macos 
+bash scripts/dependencies_darwin.sh
+
+# linux
+bash scripts/dependencies_linux.sh
+```
+
+Install right version of tools
+```bash
+asdf install 
+```
+
+From now you can use Taskfile to run repetitive commands, for example:
+```bash
+task docs
+```
+
 ## Testing
 
 We would appreciate if you test your code on your Synology NAS (if you own one),

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,44 @@
+# https://taskfile.dev
+
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - task --list
+    silent: true
+
+  dependencies:
+    desc: Install dependencies to work with this repo
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - echo "Installing dependencies..."
+      - bash scripts/dependencies_{{OS}}.sh "{{ARCH}}"
+
+  install:
+    desc: Install all tools required to work with this project
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - echo "Installing the tools for project..."
+      - bash scripts/install.sh
+
+  docs-parser:
+    desc: Parse the documentation files
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - echo "Parsing the documentation files..."
+      - python3 docs_parser.py -a
+
+  docs-build:
+    desc: Build the documentation website
+    dir: '{{.TASKFILE_DIR}}/documentation'
+    cmds:
+      - npm ci
+      - npm run build
+
+  docs:
+    desc: Parse the documentation files and build the documentation website
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - task: docs-parser
+      - task: docs-build

--- a/scripts/dependencies_darwin.sh
+++ b/scripts/dependencies_darwin.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# script to install dependencies for asdf on Linux
+
+# https://asdf-vm.com/guide/getting-started.html#plugin-dependencies
+# https://asdf-vm.com/guide/getting-started.html#install-dependencies
+echo "Installing dependencies for macOS..."
+brew install coreutils git bash gpg gawk asdf
+
+echo "Installing asdf..."
+brew install asdf
+
+echo "Installing asdf plugins..."
+asdf plugin add nodejs
+asdf plugin add python
+asdf plugin add task

--- a/scripts/dependencies_linux.sh
+++ b/scripts/dependencies_linux.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# script to install dependencies for asdf on Linux
+
+# TODO: architecture detection and use package manager for the specific distribution
+
+# https://asdf-vm.com/guide/getting-started.html#plugin-dependencies
+# https://asdf-vm.com/guide/getting-started.html#install-dependencies
+echo "Installing dependencies for linux..."
+apt update
+apt install -y git bash dirmngr gpg curl gawk golang make
+
+echo "Installing asdf..."
+go install github.com/asdf-vm/asdf/cmd/asdf@v0.18.0
+ln -s "$(go env GOPATH)/bin/asdf" /usr/local/bin/asdf
+
+echo "Installing asdf plugins..."
+"$(go env GOPATH)/bin/asdf" plugin add nodejs
+"$(go env GOPATH)/bin/asdf" plugin add python
+"$(go env GOPATH)/bin/asdf" plugin add task

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# script to install same tools versions for this project
+
+# install tools versions specified in .tool-versions file
+asdf install


### PR DESCRIPTION
### Description 
I noticed that we don't have any tools with specified versions, except for [Node.js 18](https://github.com/N4S4/synology-api/blob/master/.github/workflows/test-deploy.yml#L22) in the GitHub workflow.
<img width="488" alt="image" src="https://github.com/user-attachments/assets/133e4843-0c1c-4a42-bd76-4fe57d020083" />

To address this, I added [asdf](https://asdf-vm.com/guide/introduction.html) to the repository. This will help us install consistent versions of tools like Node.js, Python, and others for both development and future GitHub workflows.

Because some tools require additional dependencies, I created scripts in the `scripts` directory to install the necessary packages. I also added a [Taskfile](https://taskfile.dev/) (similar to a Makefile) with tasks for repetitive actions, such as generating documentation.

Now, for example, we can build the entire documentation with the following command:
```
task docs
```

### Changes
- New scripts
```bash
$ tree ./scripts
./scripts
├── dependencies_darwin.sh
├── dependencies_linux.sh
└── install.sh
```

- Taskfile with few tasks
```
$ task --list
task: Available tasks for this project:
* dependencies:       Install dependencies to work with this repo
* docs:               Parse the documentation files and build the documentation website
* docs-build:         Build the documentation website
* docs-parser:        Parse the documentation files
* install:            Install all tools required to work with this project
```

- asdf `.tool-versions` with versions of tools we are using
```
$ cat .tool-versions
nodejs 18.18.0
python 3.9.6
task 3.44.0
```

- version of nodejs is in GHA workflow (.github/workflows/test-deploy.yml) set by version from .tool-version
  - no mismatch between dev version and version used in GHA
<img width="536" alt="image" src="https://github.com/user-attachments/assets/60ef0854-8f8a-4f53-bff9-8e7d3b31e706" />

- updated CONTRIBUTING.md file

