### PR TITLE
fix: change trigger for auto-generating docs from PR to push on master branch

### DIFF
--- a/.github/workflows/auto-generate-docs.yml
+++ b/.github/workflows/auto-generate-docs.yml
@@ -1,7 +1,7 @@
 name: Auto Generate Docs
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 


### PR DESCRIPTION
### Description

This is a fix for: https://github.com/N4S4/synology-api/pull/248, where the workflow failed due to permission issues. With this change, documentation will be generated after a pull request is merged into the master branch by the repository owner. This serves as a workaround for write permission limitations.