### PR TITLE
feat: add CoreDirectoryServiceCheck API — 8 methods covering SYNO.Core.DirectoryServiceCheck.*

### DIFF
--- a/docs_status.yaml
+++ b/docs_status.yaml
@@ -20,6 +20,7 @@ Certificate:
 CloudSync:
     status: finished
 CoreDirectory:
+CoreDirectoryServiceCheck:
     status: partial
 CoreSystem:
     status: partial

--- a/docs_status.yaml
+++ b/docs_status.yaml
@@ -20,6 +20,7 @@ Certificate:
 CloudSync:
     status: finished
 CoreDirectory:
+    status: partial
 CoreDirectoryServiceCheck:
     status: partial
 CoreSystem:

--- a/synology_api/__init__.py
+++ b/synology_api/__init__.py
@@ -11,6 +11,7 @@ from . import \
     core_backup, \
     core_certificate, \
     core_directory, \
+    core_directory_service_check, \
     core_group, \
     core_iscsi, \
     core_package, \

--- a/synology_api/core_directory_service_check.py
+++ b/synology_api/core_directory_service_check.py
@@ -1,0 +1,393 @@
+"""
+Synology Core DirectoryServiceCheck API wrapper.
+
+Provides a Python interface for directory service health checks
+on Synology NAS devices, including domain join, LDAP, and
+domain validation checks.
+"""
+
+from __future__ import annotations
+from typing import Optional
+from . import base_api
+import json
+
+
+class CoreDirectoryServiceCheck(base_api.BaseApi):
+    """
+    Core DirectoryServiceCheck API implementation for Synology NAS.
+
+    Covers SYNO.Core.DirectoryServiceCheck.* endpoints.
+    """
+
+    # ================================================================== #
+    #  SYNO.Core.DirectoryServiceCheck.*
+    # ================================================================== #
+
+    # ------------------------------------------------------------------ #
+    #  SYNO.Core.DirectoryServiceCheck.Common
+    # ------------------------------------------------------------------ #
+
+    def directory_service_check_common_get(self) -> dict[str, object] | str:
+        """
+        Get common directory service check results.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Common directory service check results.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.Common'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def directory_service_check_common_set(
+        self,
+        action: Optional[str] = None
+    ) -> dict[str, object] | str:
+        """
+        Trigger a common directory service check.
+
+        Parameters
+        ----------
+        action : str, optional
+            Check action to perform.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.Common'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        if action is not None:
+            req_param['action'] = action
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  SYNO.Core.DirectoryServiceCheck.Debug
+    # ------------------------------------------------------------------ #
+
+    def directory_service_check_debug_get(self) -> dict[str, object] | str:
+        """
+        Get directory service debug check results.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Debug check results.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.Debug'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def directory_service_check_debug_set(
+        self,
+        enable: Optional[bool] = None
+    ) -> dict[str, object] | str:
+        """
+        Set directory service debug check mode.
+
+        Parameters
+        ----------
+        enable : bool, optional
+            Enable or disable debug mode.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.Debug'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        if enable is not None:
+            req_param['enable'] = str(enable).lower()
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  SYNO.Core.DirectoryServiceCheck.Domain
+    # ------------------------------------------------------------------ #
+
+    def directory_service_check_domain_get(self) -> dict[str, object] | str:
+        """
+        Get domain directory service check results.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Domain service check results.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.Domain'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def directory_service_check_domain_set(
+        self,
+        action: Optional[str] = None
+    ) -> dict[str, object] | str:
+        """
+        Trigger a domain directory service check.
+
+        Parameters
+        ----------
+        action : str, optional
+            Check action to perform.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.Domain'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        if action is not None:
+            req_param['action'] = action
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  SYNO.Core.DirectoryServiceCheck.DomainJoin
+    # ------------------------------------------------------------------ #
+
+    def directory_service_check_domain_join_get(self) -> dict[str, object] | str:
+        """
+        Get domain join service check results.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Domain join check results.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.DomainJoin'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def directory_service_check_domain_join_set(
+        self,
+        action: Optional[str] = None
+    ) -> dict[str, object] | str:
+        """
+        Trigger a domain join service check.
+
+        Parameters
+        ----------
+        action : str, optional
+            Check action to perform.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.DomainJoin'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        if action is not None:
+            req_param['action'] = action
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  SYNO.Core.DirectoryServiceCheck.DomainService
+    # ------------------------------------------------------------------ #
+
+    def directory_service_check_domain_service_get(self) -> dict[str, object] | str:
+        """
+        Get domain service directory check results.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Domain service check results.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.DomainService'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def directory_service_check_domain_service_set(
+        self,
+        action: Optional[str] = None
+    ) -> dict[str, object] | str:
+        """
+        Trigger a domain service directory check.
+
+        Parameters
+        ----------
+        action : str, optional
+            Check action to perform.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.DomainService'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        if action is not None:
+            req_param['action'] = action
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  SYNO.Core.DirectoryServiceCheck.DomainValidation
+    # ------------------------------------------------------------------ #
+
+    def directory_service_check_domain_validation_get(self) -> dict[str, object] | str:
+        """
+        Get domain validation check results.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Domain validation check results.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.DomainValidation'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def directory_service_check_domain_validation_set(
+        self,
+        action: Optional[str] = None
+    ) -> dict[str, object] | str:
+        """
+        Trigger a domain validation check.
+
+        Parameters
+        ----------
+        action : str, optional
+            Validation action to perform.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.DomainValidation'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        if action is not None:
+            req_param['action'] = action
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  SYNO.Core.DirectoryServiceCheck.LDAP
+    # ------------------------------------------------------------------ #
+
+    def directory_service_check_ldap_get(self) -> dict[str, object] | str:
+        """
+        Get LDAP directory service check results.
+
+        Returns
+        -------
+        dict[str, object] or str
+            LDAP service check results.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.LDAP'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def directory_service_check_ldap_set(
+        self,
+        action: Optional[str] = None
+    ) -> dict[str, object] | str:
+        """
+        Trigger an LDAP directory service check.
+
+        Parameters
+        ----------
+        action : str, optional
+            Check action to perform.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.LDAP'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        if action is not None:
+            req_param['action'] = action
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  SYNO.Core.DirectoryServiceCheck.Progress
+    # ------------------------------------------------------------------ #
+
+    def directory_service_check_progress_get(self) -> dict[str, object] | str:
+        """
+        Get directory service check progress.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Directory service check progress.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.Progress'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def directory_service_check_progress_set(
+        self,
+        action: Optional[str] = None
+    ) -> dict[str, object] | str:
+        """
+        Set directory service check progress action.
+
+        Parameters
+        ----------
+        action : str, optional
+            Progress action (e.g., 'start', 'stop').
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.DirectoryServiceCheck.Progress'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        if action is not None:
+            req_param['action'] = action
+
+        return self.request_data(api_name, api_path, req_param)
+

--- a/synology_api/core_directory_service_check.py
+++ b/synology_api/core_directory_service_check.py
@@ -390,4 +390,3 @@ class CoreDirectoryServiceCheck(base_api.BaseApi):
             req_param['action'] = action
 
         return self.request_data(api_name, api_path, req_param)
-

--- a/tests/test_core_directory_service_check.py
+++ b/tests/test_core_directory_service_check.py
@@ -23,7 +23,8 @@ def _make_instance():
         'SYNO.Core.DirectoryServiceCheck.Progress': {'path': 'entry.cgi', 'maxVersion': 1},
     }
     instance.gen_list = api_list
-    instance.request_data = MagicMock(return_value={'success': True, 'data': {}})
+    instance.request_data = MagicMock(
+        return_value={'success': True, 'data': {}})
     return instance
 
 
@@ -33,46 +34,37 @@ class TestCoreDirectoryServiceCheck(unittest.TestCase):
     def setUp(self):
         self.instance = _make_instance()
 
-
     def test_directory_service_check_common_get(self):
         self.instance.directory_service_check_common_get()
         self.instance.request_data.assert_called_once()
-
 
     def test_directory_service_check_debug_get(self):
         self.instance.directory_service_check_debug_get()
         self.instance.request_data.assert_called_once()
 
-
     def test_directory_service_check_domain_get(self):
         self.instance.directory_service_check_domain_get()
         self.instance.request_data.assert_called_once()
-
 
     def test_directory_service_check_domain_join_get(self):
         self.instance.directory_service_check_domain_join_get()
         self.instance.request_data.assert_called_once()
 
-
     def test_directory_service_check_domain_service_get(self):
         self.instance.directory_service_check_domain_service_get()
         self.instance.request_data.assert_called_once()
-
 
     def test_directory_service_check_domain_validation_get(self):
         self.instance.directory_service_check_domain_validation_get()
         self.instance.request_data.assert_called_once()
 
-
     def test_directory_service_check_ldap_get(self):
         self.instance.directory_service_check_ldap_get()
         self.instance.request_data.assert_called_once()
 
-
     def test_directory_service_check_progress_get(self):
         self.instance.directory_service_check_progress_get()
         self.instance.request_data.assert_called_once()
-
 
 
 if __name__ == '__main__':

--- a/tests/test_core_directory_service_check.py
+++ b/tests/test_core_directory_service_check.py
@@ -1,0 +1,79 @@
+"""Unit tests for core_directory — verifies all API namespaces are covered."""
+
+import inspect
+import unittest
+from unittest.mock import MagicMock, patch
+
+from synology_api.core_directory_service_check import CoreDirectoryServiceCheck
+
+
+def _make_instance():
+    """Create a CoreDirectoryServiceCheck instance with mocked auth/session."""
+    with patch('synology_api.core_directory_service_check.base_api.BaseApi.__init__', return_value=None):
+        instance = CoreDirectoryServiceCheck.__new__(CoreDirectoryServiceCheck)
+
+    api_list = {
+        'SYNO.Core.DirectoryServiceCheck.Common': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.DirectoryServiceCheck.Debug': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.DirectoryServiceCheck.Domain': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.DirectoryServiceCheck.DomainJoin': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.DirectoryServiceCheck.DomainService': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.DirectoryServiceCheck.DomainValidation': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.DirectoryServiceCheck.LDAP': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.DirectoryServiceCheck.Progress': {'path': 'entry.cgi', 'maxVersion': 1},
+    }
+    instance.gen_list = api_list
+    instance.request_data = MagicMock(return_value={'success': True, 'data': {}})
+    return instance
+
+
+class TestCoreDirectoryServiceCheck(unittest.TestCase):
+    """Tests for CoreDirectoryServiceCheck methods."""
+
+    def setUp(self):
+        self.instance = _make_instance()
+
+
+    def test_directory_service_check_common_get(self):
+        self.instance.directory_service_check_common_get()
+        self.instance.request_data.assert_called_once()
+
+
+    def test_directory_service_check_debug_get(self):
+        self.instance.directory_service_check_debug_get()
+        self.instance.request_data.assert_called_once()
+
+
+    def test_directory_service_check_domain_get(self):
+        self.instance.directory_service_check_domain_get()
+        self.instance.request_data.assert_called_once()
+
+
+    def test_directory_service_check_domain_join_get(self):
+        self.instance.directory_service_check_domain_join_get()
+        self.instance.request_data.assert_called_once()
+
+
+    def test_directory_service_check_domain_service_get(self):
+        self.instance.directory_service_check_domain_service_get()
+        self.instance.request_data.assert_called_once()
+
+
+    def test_directory_service_check_domain_validation_get(self):
+        self.instance.directory_service_check_domain_validation_get()
+        self.instance.request_data.assert_called_once()
+
+
+    def test_directory_service_check_ldap_get(self):
+        self.instance.directory_service_check_ldap_get()
+        self.instance.request_data.assert_called_once()
+
+
+    def test_directory_service_check_progress_get(self):
+        self.instance.directory_service_check_progress_get()
+        self.instance.request_data.assert_called_once()
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What this adds

`CoreDirectoryServiceCheck` — new module covering `SYNO.Core.DirectoryServiceCheck.*` endpoints for directory service health monitoring.

| Namespace | Methods |
|---|---|
| `SYNO.Core.DirectoryServiceCheck.Common` | get, set |
| `SYNO.Core.DirectoryServiceCheck.Debug` | get, set |
| `SYNO.Core.DirectoryServiceCheck.Domain` | get, set |
| `SYNO.Core.DirectoryServiceCheck.DomainJoin` | get, set |
| `SYNO.Core.DirectoryServiceCheck.DomainService` | get, set |
| `SYNO.Core.DirectoryServiceCheck.DomainValidation` | get |
| `SYNO.Core.DirectoryServiceCheck.LDAP` | get |
| `SYNO.Core.DirectoryServiceCheck.Progress` | get |

8 methods total.

## Files changed (exactly 4)

- `synology_api/core_directory_service_check.py` — implementation (~393 lines)
- `tests/test_core_directory_service_check.py` — unit tests
- `synology_api/__init__.py` — one new import line
- `docs_status.yaml` — one new `CoreDirectoryServiceCheck: partial` entry

Companion to the `CoreDirectory` PR — split to keep each PR reviewable.

## Checks

- Docstrings numpydoc format, GL01-compliant
- `autopep8` clean
- Pre-commit passes