### PR TITLE
feat: 2FA device token support and OTP encryption fix

### DIFF
--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -60,9 +60,12 @@ class Authentication:
     otp_code : str, optional
         One-time password for 2FA.
     device_id : str, optional
-        Device ID for device binding.
+        Device ID for device binding (trusted device, skips OTP).
     device_name : str, optional
         Device name for device binding.
+    enable_device_token : bool, optional
+        Request a device token after OTP login so future sessions can skip
+        OTP.  Read the returned token via the ``did`` property after login.
     """
 
     def __init__(self,
@@ -76,7 +79,8 @@ class Authentication:
                  debug: bool = True,
                  otp_code: Optional[str] = None,
                  device_id: Optional[str] = None,
-                 device_name: Optional[str] = None
+                 device_name: Optional[str] = None,
+                 enable_device_token: bool = False,
                  ) -> None:
         """
         Initialize the Authentication object for Synology DSM.
@@ -102,9 +106,15 @@ class Authentication:
         otp_code : str, optional
             One-time password for 2FA (default is None).
         device_id : str, optional
-            Device ID for device binding (default is None).
+            Device ID for device binding; when supplied DSM skips OTP
+            (default is None).
         device_name : str, optional
             Device name for device binding (default is None).
+        enable_device_token : bool, optional
+            When True, ask DSM to issue a device token after a successful OTP
+            login.  The token is available via the ``did`` property and can be
+            passed as ``device_id`` in future sessions to bypass OTP
+            (default is False).
 
         Returns
         -------
@@ -125,6 +135,8 @@ class Authentication:
         self._otp_code: Optional[str] = otp_code
         self._device_id: Optional[str] = device_id
         self._device_name: Optional[str] = device_name
+        self._enable_device_token: bool = enable_device_token
+        self._did: Optional[str] = None
 
         if self._verify is False:
             disable_warnings(InsecureRequestWarning)
@@ -218,9 +230,9 @@ class Authentication:
 
         params_enc = {
             'account': self._username,
-            'enable_device_token': 'no',
+            'enable_device_token': 'yes' if self._enable_device_token else 'no',
             'logintype': 'local',
-            'otp_code': '',
+            'otp_code': self._otp_code or '',
             'rememberme': 0,
             'passwd': self._password,
             'session': 'webui',  # Hardcoded for handle non administrator users API usage
@@ -232,8 +244,6 @@ class Authentication:
             encrypted_params = self.encrypt_params(params_enc)
             params.update(encrypted_params)
 
-        if self._otp_code:
-            params['otp_code'] = self._otp_code
         if self._device_id is not None and self._device_name is not None:
             params['device_id'] = self._device_id
             params['device_name'] = self._device_name
@@ -270,6 +280,7 @@ class Authentication:
             if not error_code:
                 self._sid = session_request_json['data']['sid']
                 self._syno_token = session_request_json['data']['synotoken']
+                self._did = session_request_json['data'].get('did')
                 self._session_expire = False
                 if self._debug is True:
                     print('User logged in, new session started!')
@@ -962,6 +973,22 @@ class Authentication:
             Synology token.
         """
         return self._syno_token
+
+    @property
+    def did(self) -> Optional[str]:
+        """
+        Get the device ID token issued by DSM after a trusted-device login.
+
+        This is populated only when ``enable_device_token=True`` was passed and
+        login succeeded with a valid OTP.  Persist this value and supply it as
+        ``device_id`` in future sessions to bypass OTP verification.
+
+        Returns
+        -------
+        str or None
+            Device ID token, or None if not yet issued.
+        """
+        return self._did
 
 
 class AESCipher(object):

--- a/synology_api/base_api.py
+++ b/synology_api/base_api.py
@@ -36,9 +36,14 @@ class BaseApi(object):
     otp_code : str, optional
         The OTP code to use for authentication. Defaults to `None`.
     device_id : str, optional
-        Device ID for device binding. Defaults to `None`.
+        Device ID for device binding (trusted device, skips OTP). Defaults to
+        `None`.
     device_name : str, optional
         Device name for device binding. Defaults to `None`.
+    enable_device_token : bool, optional
+        When True, request a device token from DSM after a successful OTP
+        login.  Read the token back via the ``did`` attribute and persist it
+        for use as ``device_id`` in future sessions. Defaults to `False`.
     application : str, optional
         The application context for API list retrieval. Defaults to `'Core'`.
     """
@@ -58,6 +63,7 @@ class BaseApi(object):
                  otp_code: Optional[str] = None,
                  device_id: Optional[str] = None,
                  device_name: Optional[str] = None,
+                 enable_device_token: bool = False,
                  application: str = 'Core',
                  ) -> None:
         """
@@ -84,9 +90,14 @@ class BaseApi(object):
         otp_code : str, optional
             The OTP code to use for authentication. Defaults to `None`.
         device_id : str, optional
-            Device ID for device binding. Defaults to `None`.
+            Device ID for a previously trusted device; when supplied DSM skips
+            OTP verification. Defaults to `None`.
         device_name : str, optional
             Device name for device binding. Defaults to `None`.
+        enable_device_token : bool, optional
+            When True, ask DSM to issue a device token after a successful OTP
+            login.  Retrieve it via ``self.did`` and store it for use as
+            ``device_id`` in future sessions. Defaults to `False`.
         application : str, optional
             The application context for API list retrieval. Defaults to `'Core'`.
 
@@ -107,7 +118,7 @@ class BaseApi(object):
 
             self.session = syn.Authentication(
                 ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code,
-                device_id, device_name
+                device_id, device_name, enable_device_token
             )
             self.session.login()
             self.session.get_api_list(self.application)
@@ -123,6 +134,7 @@ class BaseApi(object):
         self.gen_list: Any = self.session.full_api_list
         self._sid: str = self.session.sid
         self.base_url: str = self.session.base_url
+        self.did: Optional[str] = self.session.did
 
     def logout(self) -> None:
         """


### PR DESCRIPTION
## Summary

- Add `enable_device_token` parameter to `Authentication` and `BaseApi` so callers can request a DSM trusted-device token after a successful OTP login
- Capture the `did` (device ID) returned by DSM and expose it via a `did` property/attribute — persist this and pass it as `device_id` in future sessions to bypass OTP entirely
- Fix OTP code being sent in plaintext over HTTP: `otp_code` is now placed inside `params_enc` so it is AES-encrypted alongside credentials on non-HTTPS connections

## Usage

```python
# First login — supply OTP and request a device token
api = FileStation("192.168.1.1", "5000", "user", "pass",
                  otp_code="123456", enable_device_token=True)
device_id = api.did  # persist this value

# Future logins — no OTP needed
api = FileStation("192.168.1.1", "5000", "user", "pass",
                  device_id=device_id, device_name="my-script")
```

## Test plan

- [ ] Login with `otp_code` + `enable_device_token=True` — verify `api.did` is populated
- [ ] Reuse returned `did` as `device_id` in a second session — verify login succeeds without OTP
- [ ] Login with `otp_code` over HTTP — verify OTP is no longer visible in plaintext in captured traffic
- [ ] Login without 2FA enabled — verify no regression (did is None, behaviour unchanged)