### PR TITLE
feat: add CoreSecurity API coverage

### DIFF
--- a/docs_status.yaml
+++ b/docs_status.yaml
@@ -23,6 +23,8 @@ CoreDirectory:
     status: partial
 CoreDirectoryServiceCheck:
     status: partial
+CoreSecurity:
+    status: partial
 CoreStorage:
     status: partial
 CoreSystem:

--- a/synology_api/__init__.py
+++ b/synology_api/__init__.py
@@ -15,6 +15,7 @@ from . import \
     core_group, \
     core_iscsi, \
     core_package, \
+    core_security, \
     core_share, \
     core_storage, \
     core_sys_info, \

--- a/synology_api/core_security.py
+++ b/synology_api/core_security.py
@@ -1,0 +1,598 @@
+"""
+Synology Core Security API wrapper.
+
+This module provides a Python interface for managing security settings on
+Synology NAS devices, including auto-block rules, firewall configuration,
+DoS protection, SmartBlock, OTP, and trusted device management.
+"""
+
+from __future__ import annotations
+import json
+from . import base_api
+
+
+class CoreSecurity(base_api.BaseApi):
+    """
+    Core Security API implementation for Synology NAS.
+
+    Provides methods to manage security features including auto-block rules,
+    firewall settings, DoS protection, SmartBlock, OTP, and trusted devices.
+    """
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.AutoBlock.Rules
+    # ------------------------------------------------------------------
+
+    def autoblock_rules_get(self) -> dict[str, object] | str:
+        """
+        Get auto-block rules.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Auto-block rules configuration.
+        """
+        api_name = 'SYNO.Core.Security.AutoBlock.Rules'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def autoblock_rules_list(self) -> dict[str, object] | str:
+        """
+        List all auto-block rules.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of auto-block rules.
+        """
+        api_name = 'SYNO.Core.Security.AutoBlock.Rules'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def autoblock_rules_set(self, rules: list[dict[str, object]]) -> dict[str, object] | str:
+        """
+        Set auto-block rules.
+
+        Parameters
+        ----------
+        rules : list[dict[str, object]]
+            List of rule objects to apply.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.AutoBlock.Rules'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'set',
+            'rules': json.dumps(rules),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def autoblock_rules_delete(self, rules: list[dict[str, object]]) -> dict[str, object] | str:
+        """
+        Delete auto-block rules.
+
+        Parameters
+        ----------
+        rules : list[dict[str, object]]
+            List of rule objects to delete.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the delete operation.
+        """
+        api_name = 'SYNO.Core.Security.AutoBlock.Rules'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'delete',
+            'rules': json.dumps(rules),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.DSM
+    # ------------------------------------------------------------------
+
+    def security_dsm_get(self) -> dict[str, object] | str:
+        """
+        Get DSM security settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            DSM security settings.
+        """
+        api_name = 'SYNO.Core.Security.DSM'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def security_dsm_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set DSM security settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of DSM security settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.DSM'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.DSM.Embed
+    # ------------------------------------------------------------------
+
+    def security_dsm_embed_get(self) -> dict[str, object] | str:
+        """
+        Get DSM embed security settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            DSM embed security settings.
+        """
+        api_name = 'SYNO.Core.Security.DSM.Embed'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def security_dsm_embed_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set DSM embed security settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of embed security settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.DSM.Embed'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.DSM.Proxy
+    # ------------------------------------------------------------------
+
+    def security_dsm_proxy_get(self) -> dict[str, object] | str:
+        """
+        Get DSM proxy security settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            DSM proxy security settings.
+        """
+        api_name = 'SYNO.Core.Security.DSM.Proxy'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def security_dsm_proxy_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set DSM proxy security settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of proxy security settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.DSM.Proxy'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.DoS
+    # ------------------------------------------------------------------
+
+    def security_dos_get(self) -> dict[str, object] | str:
+        """
+        Get DoS protection settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            DoS protection settings.
+        """
+        api_name = 'SYNO.Core.Security.DoS'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def security_dos_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set DoS protection settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of DoS protection settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.DoS'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.Firewall
+    # ------------------------------------------------------------------
+
+    def firewall_get(self) -> dict[str, object] | str:
+        """
+        Get firewall status and settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Firewall status and settings.
+        """
+        api_name = 'SYNO.Core.Security.Firewall'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set firewall settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of firewall settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.Firewall'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.Firewall.Adapter
+    # ------------------------------------------------------------------
+
+    def firewall_adapter_get(self) -> dict[str, object] | str:
+        """
+        Get firewall adapter configuration.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Firewall adapter configuration.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Adapter'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_adapter_list(self) -> dict[str, object] | str:
+        """
+        List firewall adapters.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of firewall adapters.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Adapter'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.Firewall.Conf
+    # ------------------------------------------------------------------
+
+    def firewall_conf_get(self) -> dict[str, object] | str:
+        """
+        Get firewall configuration.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Firewall configuration.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Conf'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_conf_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set firewall configuration.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of firewall configuration to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Conf'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.Firewall.Geoip
+    # ------------------------------------------------------------------
+
+    def firewall_geoip_get(self) -> dict[str, object] | str:
+        """
+        Get geo-IP blocking settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Geo-IP blocking settings.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Geoip'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_geoip_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set geo-IP blocking settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of geo-IP blocking settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Geoip'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.Firewall.Profile.Apply
+    # ------------------------------------------------------------------
+
+    def firewall_profile_apply(self, profile_name: str = '') -> dict[str, object] | str:
+        """
+        Apply a firewall profile.
+
+        Parameters
+        ----------
+        profile_name : str, optional
+            Name of the firewall profile to apply. Defaults to empty string.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the apply operation.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Profile.Apply'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'start',
+            'profile_name': profile_name,
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_profile_apply_status(self) -> dict[str, object] | str:
+        """
+        Get the status of a firewall profile apply operation.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Status of the apply operation.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Profile.Apply'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'status'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.Firewall.Rules
+    # ------------------------------------------------------------------
+
+    def firewall_rules_get(self) -> dict[str, object] | str:
+        """
+        Get firewall rules.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Firewall rules configuration.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Rules'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_rules_list(self) -> dict[str, object] | str:
+        """
+        List all firewall rules.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of firewall rules.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Rules'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_rules_set(self, rules: list[dict[str, object]]) -> dict[str, object] | str:
+        """
+        Set firewall rules.
+
+        Parameters
+        ----------
+        rules : list[dict[str, object]]
+            List of firewall rule objects to apply.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Rules'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'set',
+            'rules': json.dumps(rules),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_rules_delete(self, rules: list[dict[str, object]]) -> dict[str, object] | str:
+        """
+        Delete firewall rules.
+
+        Parameters
+        ----------
+        rules : list[dict[str, object]]
+            List of firewall rule objects to delete.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the delete operation.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Rules'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'delete',
+            'rules': json.dumps(rules),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Security.Firewall.Rules.Serv
+    # ------------------------------------------------------------------
+
+    def firewall_rules_serv_get(self) -> dict[str, object] | str:
+        """
+        Get service-based firewall rules.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Service-based firewall rules.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Rules.Serv'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def firewall_rules_serv_list(self) -> dict[str, object] | str:
+        """
+        List service-based firewall rules.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of service-based firewall rules.
+        """
+        api_name = 'SYNO.Core.Security.Firewall.Rules.Serv'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------

--- a/tests/test_core_security.py
+++ b/tests/test_core_security.py
@@ -1,0 +1,155 @@
+"""Unit tests for core_security — verifies all API namespaces are covered."""
+
+import inspect
+import unittest
+from unittest.mock import MagicMock, patch
+
+from synology_api.core_security import CoreSecurity
+
+
+def _make_instance():
+    """Create a CoreSecurity instance with mocked auth/session."""
+    with patch('synology_api.core_security.base_api.BaseApi.__init__', return_value=None):
+        instance = CoreSecurity.__new__(CoreSecurity)
+
+    api_list = {
+        'SYNO.Core.Security.AutoBlock.Rules': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.DSM': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.DSM.Embed': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.DSM.Proxy': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.DoS': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.Firewall': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.Firewall.Adapter': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.Firewall.Conf': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.Firewall.Geoip': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.Firewall.Profile.Apply': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.Firewall.Rules': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Security.Firewall.Rules.Serv': {'path': 'entry.cgi', 'maxVersion': 1},
+    }
+    instance.gen_list = api_list
+    instance.request_data = MagicMock(
+        return_value={'success': True, 'data': {}})
+    return instance
+
+
+class TestCoreSecurity(unittest.TestCase):
+    """Tests for CoreSecurity methods."""
+
+    def setUp(self):
+        self.instance = _make_instance()
+
+    def test_autoblock_rules_delete(self):
+        self.instance.autoblock_rules_delete(rules={"test": True})
+        self.instance.request_data.assert_called_once()
+
+    def test_autoblock_rules_get(self):
+        self.instance.autoblock_rules_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_autoblock_rules_list(self):
+        self.instance.autoblock_rules_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_autoblock_rules_set(self):
+        self.instance.autoblock_rules_set(rules={"test": True})
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_adapter_get(self):
+        self.instance.firewall_adapter_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_adapter_list(self):
+        self.instance.firewall_adapter_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_conf_get(self):
+        self.instance.firewall_conf_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_conf_set(self):
+        self.instance.firewall_conf_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_geoip_get(self):
+        self.instance.firewall_geoip_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_geoip_set(self):
+        self.instance.firewall_geoip_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_get(self):
+        self.instance.firewall_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_profile_apply(self):
+        self.instance.firewall_profile_apply(profile_name='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_profile_apply_status(self):
+        self.instance.firewall_profile_apply_status()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_rules_delete(self):
+        self.instance.firewall_rules_delete(rules={"test": True})
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_rules_get(self):
+        self.instance.firewall_rules_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_rules_list(self):
+        self.instance.firewall_rules_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_rules_serv_get(self):
+        self.instance.firewall_rules_serv_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_rules_serv_list(self):
+        self.instance.firewall_rules_serv_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_rules_set(self):
+        self.instance.firewall_rules_set(rules={"test": True})
+        self.instance.request_data.assert_called_once()
+
+    def test_firewall_set(self):
+        self.instance.firewall_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_security_dos_get(self):
+        self.instance.security_dos_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_security_dos_set(self):
+        self.instance.security_dos_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_security_dsm_embed_get(self):
+        self.instance.security_dsm_embed_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_security_dsm_embed_set(self):
+        self.instance.security_dsm_embed_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_security_dsm_get(self):
+        self.instance.security_dsm_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_security_dsm_proxy_get(self):
+        self.instance.security_dsm_proxy_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_security_dsm_proxy_set(self):
+        self.instance.security_dsm_proxy_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_security_dsm_set(self):
+        self.instance.security_dsm_set()
+        self.instance.request_data.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add CoreSecurity wrapper for SYNO.Core.Security AutoBlock, DSM, DoS, and Firewall endpoints
- register the module in package exports and docs status
- add focused unit coverage for the new wrapper methods

## Size guard
- production code diff: 599 changed lines under synology_api
- tests/docs excluded from the requested 1000 LOC cap

## Verification
- `uv run --with pytest --with requests --with urllib3 --with requests_toolbelt --with tqdm --with cryptography --with treelib --with noiseprotocol python -m pytest tests/test_core_security.py`
