### PR TITLE
feat: add CoreExternalDevice API coverage

### DIFF
--- a/docs_status.yaml
+++ b/docs_status.yaml
@@ -23,6 +23,8 @@ CoreDirectory:
     status: partial
 CoreDirectoryServiceCheck:
     status: partial
+CoreExternalDevice:
+    status: partial
 CoreStorage:
     status: partial
 CoreSystem:

--- a/synology_api/__init__.py
+++ b/synology_api/__init__.py
@@ -12,6 +12,7 @@ from . import \
     core_certificate, \
     core_directory, \
     core_directory_service_check, \
+    core_external_device, \
     core_group, \
     core_iscsi, \
     core_package, \

--- a/synology_api/core_external_device.py
+++ b/synology_api/core_external_device.py
@@ -1,0 +1,622 @@
+"""
+Synology Core External Device API wrapper.
+
+Provides a Python interface for managing external devices on Synology NAS,
+including Bluetooth, printers, and storage expansion units.
+"""
+
+from __future__ import annotations
+from typing import Optional
+from . import base_api
+
+
+class CoreExternalDevice(base_api.BaseApi):
+    """
+    Core External Device API implementation for Synology NAS.
+
+    Covers Bluetooth, printer (driver, network, USB, OAuth), and storage
+    (expansion unit, settings) endpoints not handled by other modules.
+    """
+
+    # ------------------------------------------------------------------ #
+    #  Bluetooth                                                          #
+    # ------------------------------------------------------------------ #
+
+    def bluetooth_get(self) -> dict[str, object] | str:
+        """
+        Get Bluetooth adapter status.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the bluetooth get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Bluetooth'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def bluetooth_set(self, enable: bool = True) -> dict[str, object] | str:
+        """
+        Enable or disable the Bluetooth adapter.
+
+        Parameters
+        ----------
+        enable : bool, optional
+            The enable value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the bluetooth set operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Bluetooth'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set',
+                     'enable': str(enable).lower()}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def bluetooth_device_list(self) -> dict[str, object] | str:
+        """
+        List discovered Bluetooth devices.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the bluetooth device list operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Bluetooth.Device'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def bluetooth_device_get(self, device_id: str) -> dict[str, object] | str:
+        """
+        Get information for a specific Bluetooth device.
+
+        Parameters
+        ----------
+        device_id : str
+            The device id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the bluetooth device get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Bluetooth.Device'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get',
+                     'id': device_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def bluetooth_device_connect(self, device_id: str) -> dict[str, object] | str:
+        """
+        Connect to a Bluetooth device.
+
+        Parameters
+        ----------
+        device_id : str
+            The device id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the bluetooth device connect operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Bluetooth.Device'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'connect',
+                     'id': device_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def bluetooth_device_disconnect(self, device_id: str) -> dict[str, object] | str:
+        """
+        Disconnect a Bluetooth device.
+
+        Parameters
+        ----------
+        device_id : str
+            The device id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the bluetooth device disconnect operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Bluetooth.Device'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'disconnect',
+                     'id': device_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def bluetooth_settings_get(self) -> dict[str, object] | str:
+        """
+        Get Bluetooth settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the bluetooth settings get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Bluetooth.Settings'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def bluetooth_settings_set(self, discoverable: Optional[bool] = None,
+                               name: Optional[str] = None) -> dict[str, object] | str:
+        """
+        Set Bluetooth settings.
+
+        Parameters
+        ----------
+        discoverable : str, optional
+            The discoverable value.
+        name : str, optional
+            The name value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the bluetooth settings set operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Bluetooth.Settings'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param: dict[str, object] = {
+            'version': info['maxVersion'], 'method': 'set'}
+        if discoverable is not None:
+            req_param['discoverable'] = str(discoverable).lower()
+        if name is not None:
+            req_param['name'] = name
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  Default Permission                                                 #
+    # ------------------------------------------------------------------ #
+
+    def default_permission_get(self) -> dict[str, object] | str:
+        """
+        Get default permission settings for external devices.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the default permission get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.DefaultPermission'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def default_permission_set(self, permission: str) -> dict[str, object] | str:
+        """
+        Set default permission for external devices.
+
+        Parameters
+        ----------
+        permission : str
+            The permission value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the default permission set operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.DefaultPermission'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set',
+                     'permission': permission}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  Printer                                                            #
+    # ------------------------------------------------------------------ #
+
+    def printer_list(self) -> dict[str, object] | str:
+        """
+        List all printers.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer list operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_get(self, printer_id: str) -> dict[str, object] | str:
+        """
+        Get printer information.
+
+        Parameters
+        ----------
+        printer_id : str
+            The printer id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get',
+                     'id': printer_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_clean(self, printer_id: str) -> dict[str, object] | str:
+        """
+        Clean the print queue for a printer.
+
+        Parameters
+        ----------
+        printer_id : str
+            The printer id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer clean operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'clean',
+                     'id': printer_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  Printer Driver                                                     #
+    # ------------------------------------------------------------------ #
+
+    def printer_driver_list(self) -> dict[str, object] | str:
+        """
+        List available printer drivers.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer driver list operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.Driver'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_driver_get(self, driver_id: str) -> dict[str, object] | str:
+        """
+        Get a specific printer driver.
+
+        Parameters
+        ----------
+        driver_id : str
+            The driver id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer driver get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.Driver'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get',
+                     'id': driver_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  Printer Network                                                    #
+    # ------------------------------------------------------------------ #
+
+    def printer_network_list(self) -> dict[str, object] | str:
+        """
+        List network printers.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer network list operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.Network'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_network_create(self, host: str, port: int = 9100,
+                               driver_id: Optional[str] = None) -> dict[str, object] | str:
+        """
+        Add a network printer.
+
+        Parameters
+        ----------
+        host : str
+            The host value.
+        port : int, optional
+            The port value.
+        driver_id : str, optional
+            The driver id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer network create operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.Network'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param: dict[str, object] = {
+            'version': info['maxVersion'], 'method': 'create',
+            'host': host, 'port': port}
+        if driver_id is not None:
+            req_param['driver_id'] = driver_id
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_network_delete(self, printer_id: str) -> dict[str, object] | str:
+        """
+        Remove a network printer.
+
+        Parameters
+        ----------
+        printer_id : str
+            The printer id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer network delete operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.Network'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'delete',
+                     'id': printer_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_network_host_list(self) -> dict[str, object] | str:
+        """
+        List network printer hosts discovered on the network.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer network host list operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.Network.Host'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  Printer OAuth                                                      #
+    # ------------------------------------------------------------------ #
+
+    def printer_oauth_get(self) -> dict[str, object] | str:
+        """
+        Get OAuth settings for cloud printing.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer oauth get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.OAuth'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_oauth_set(self, token: str) -> dict[str, object] | str:
+        """
+        Set OAuth token for cloud printing.
+
+        Parameters
+        ----------
+        token : str
+            The token value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer oauth set operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.OAuth'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set',
+                     'token': token}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  Printer USB                                                        #
+    # ------------------------------------------------------------------ #
+
+    def printer_usb_list(self) -> dict[str, object] | str:
+        """
+        List USB printers.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer usb list operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.USB'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_usb_get(self, printer_id: str) -> dict[str, object] | str:
+        """
+        Get USB printer information.
+
+        Parameters
+        ----------
+        printer_id : str
+            The printer id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer usb get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.USB'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get',
+                     'id': printer_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def printer_usb_release(self, printer_id: str) -> dict[str, object] | str:
+        """
+        Release a USB printer from the server.
+
+        Parameters
+        ----------
+        printer_id : str
+            The printer id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the printer usb release operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Printer.USB'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'release',
+                     'id': printer_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  Storage — Expansion Unit                                           #
+    # ------------------------------------------------------------------ #
+
+    def storage_eunit_list(self) -> dict[str, object] | str:
+        """
+        List connected expansion units.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the storage eunit list operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Storage.EUnit'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_eunit_get(self, unit_id: str) -> dict[str, object] | str:
+        """
+        Get expansion unit details.
+
+        Parameters
+        ----------
+        unit_id : str
+            The unit id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the storage eunit get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Storage.EUnit'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get',
+                     'id': unit_id}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------ #
+    #  Storage — Setting                                                  #
+    # ------------------------------------------------------------------ #
+
+    def storage_setting_get(self) -> dict[str, object] | str:
+        """
+        Get external storage settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the storage setting get operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Storage.Setting'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_setting_set(self,
+                            auto_format: Optional[bool] = None,
+                            auto_mount: Optional[bool] = None) -> dict[str, object] | str:
+        """
+        Set external storage settings.
+
+        Parameters
+        ----------
+        auto_format : str, optional
+            The auto format value.
+        auto_mount : str, optional
+            The auto mount value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the storage setting set operation.
+        """
+        api_name = 'SYNO.Core.ExternalDevice.Storage.Setting'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param: dict[str, object] = {
+            'version': info['maxVersion'], 'method': 'set'}
+        if auto_format is not None:
+            req_param['auto_format'] = str(auto_format).lower()
+        if auto_mount is not None:
+            req_param['auto_mount'] = str(auto_mount).lower()
+
+        return self.request_data(api_name, api_path, req_param)

--- a/tests/test_core_external_device.py
+++ b/tests/test_core_external_device.py
@@ -1,0 +1,190 @@
+"""Unit tests for core_external_device — verifies all API namespaces are covered."""
+
+import inspect
+import unittest
+from unittest.mock import MagicMock, patch
+
+from synology_api.core_external_device import CoreExternalDevice
+
+
+def _make_instance():
+    """Create a CoreExternalDevice instance with mocked auth/session."""
+    with patch('synology_api.core_external_device.base_api.BaseApi.__init__', return_value=None):
+        instance = CoreExternalDevice.__new__(CoreExternalDevice)
+
+    api_list = {
+        'SYNO.Core.ExternalDevice.Bluetooth': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Bluetooth.Device': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Bluetooth.Settings': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.DefaultPermission': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Printer': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Printer.Driver': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Printer.Network': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Printer.Network.Host': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Printer.OAuth': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Printer.USB': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Storage.EUnit': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ExternalDevice.Storage.Setting': {'path': 'entry.cgi', 'maxVersion': 1},
+    }
+    instance.core_list = api_list
+    instance.request_data = MagicMock(
+        return_value={'success': True, 'data': {}})
+    return instance
+
+
+class TestCoreExternalDevice(unittest.TestCase):
+    """Tests for CoreExternalDevice methods."""
+
+    def setUp(self):
+        self.instance = _make_instance()
+
+    def test_bluetooth_device_connect(self):
+        self.instance.bluetooth_device_connect(device_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_bluetooth_device_disconnect(self):
+        self.instance.bluetooth_device_disconnect(device_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_bluetooth_device_get(self):
+        self.instance.bluetooth_device_get(device_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_bluetooth_device_list(self):
+        self.instance.bluetooth_device_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_bluetooth_get(self):
+        self.instance.bluetooth_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_bluetooth_set(self):
+        self.instance.bluetooth_set(enable='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_bluetooth_settings_get(self):
+        self.instance.bluetooth_settings_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_bluetooth_settings_set(self):
+        self.instance.bluetooth_settings_set(discoverable='test', name='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_default_permission_get(self):
+        self.instance.default_permission_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_default_permission_set(self):
+        self.instance.default_permission_set(permission='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_clean(self):
+        self.instance.printer_clean(printer_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_driver_get(self):
+        self.instance.printer_driver_get(driver_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_driver_list(self):
+        self.instance.printer_driver_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_get(self):
+        self.instance.printer_get(printer_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_list(self):
+        self.instance.printer_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_network_create(self):
+        self.instance.printer_network_create(
+            host='test', port=1, driver_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_network_delete(self):
+        self.instance.printer_network_delete(printer_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_network_host_list(self):
+        self.instance.printer_network_host_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_network_list(self):
+        self.instance.printer_network_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_oauth_get(self):
+        self.instance.printer_oauth_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_oauth_set(self):
+        self.instance.printer_oauth_set(token='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_usb_get(self):
+        self.instance.printer_usb_get(printer_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_usb_list(self):
+        self.instance.printer_usb_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_printer_usb_release(self):
+        self.instance.printer_usb_release(printer_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_storage_eunit_get(self):
+        self.instance.storage_eunit_get(unit_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_storage_eunit_list(self):
+        self.instance.storage_eunit_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_storage_setting_get(self):
+        self.instance.storage_setting_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_storage_setting_set(self):
+        self.instance.storage_setting_set(
+            auto_format='test', auto_mount='test')
+        self.instance.request_data.assert_called_once()
+
+
+class TestCoreExternalDeviceCoverage(unittest.TestCase):
+    """Meta-tests for API namespace coverage."""
+
+    def test_all_namespaces_covered(self):
+        """Every API namespace must be referenced in at least one method."""
+        source = inspect.getsource(CoreExternalDevice)
+        required = {
+            'SYNO.Core.ExternalDevice.Bluetooth',
+            'SYNO.Core.ExternalDevice.Bluetooth.Device',
+            'SYNO.Core.ExternalDevice.Bluetooth.Settings',
+            'SYNO.Core.ExternalDevice.DefaultPermission',
+            'SYNO.Core.ExternalDevice.Printer',
+            'SYNO.Core.ExternalDevice.Printer.Driver',
+            'SYNO.Core.ExternalDevice.Printer.Network',
+            'SYNO.Core.ExternalDevice.Printer.Network.Host',
+            'SYNO.Core.ExternalDevice.Printer.OAuth',
+            'SYNO.Core.ExternalDevice.Printer.USB',
+            'SYNO.Core.ExternalDevice.Storage.EUnit',
+            'SYNO.Core.ExternalDevice.Storage.Setting'
+        }
+        for ns in required:
+            with self.subTest(namespace=ns):
+                self.assertIn(f"'{ns}'", source)
+
+    def test_method_count(self):
+        """Verify expected number of public methods."""
+        public = [m for m in dir(CoreExternalDevice)
+                  if not m.startswith('_') and callable(getattr(CoreExternalDevice, m))
+                  and m != 'logout']
+        self.assertGreaterEqual(len(public), 28,
+                                f"Expected 28+ methods, found {len(public)}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add CoreExternalDevice wrapper coverage for Bluetooth, permissions, printer, and external storage APIs
- register the module in package exports and docs status
- add focused unit tests for request construction and namespace coverage

## Tests
- python -m pytest tests/test_core_external_device.py