### PR TITLE
feat: add CoreSecurityAuth API coverage

### DIFF
--- a/docs_status.yaml
+++ b/docs_status.yaml
@@ -31,6 +31,8 @@ CoreNetwork:
     status: partial
 CoreSecurity:
     status: partial
+CoreSecurityAuth:
+    status: partial
 CoreServiceHW:
     status: partial
 CoreStorage:

--- a/synology_api/__init__.py
+++ b/synology_api/__init__.py
@@ -19,6 +19,7 @@ from . import \
     core_notification, \
     core_package, \
     core_security, \
+    core_security_auth, \
     core_service_hw, \
     core_share, \
     core_storage, \

--- a/synology_api/core_security_auth.py
+++ b/synology_api/core_security_auth.py
@@ -1,0 +1,684 @@
+"""
+Synology Core Security (Auth/OTP/SmartBlock) API wrapper.
+
+Covers SYNO.Core.SmartBlock.*, SYNO.Core.OTP.*, TrustDevice,
+and DisableAdmin endpoints on Synology NAS devices.
+"""
+
+from __future__ import annotations
+import json
+from . import base_api
+
+
+class CoreSecurityAuth(base_api.BaseApi):
+    """
+    Core Security Auth API for SmartBlock/OTP/TrustDevice/DisableAdmin.
+
+    Covers SYNO.Core.SmartBlock.*, OTP.*, TrustDevice, and DisableAdmin endpoints.
+    """
+
+    # SYNO.Core.SmartBlock
+    # ------------------------------------------------------------------
+
+    def smartblock_get(self) -> dict[str, object] | str:
+        """
+        Get SmartBlock settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            SmartBlock settings.
+        """
+        api_name = 'SYNO.Core.SmartBlock'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set SmartBlock settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of SmartBlock settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.SmartBlock'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.SmartBlock.Device
+    # ------------------------------------------------------------------
+
+    def smartblock_device_get(self) -> dict[str, object] | str:
+        """
+        Get SmartBlock blocked devices.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Blocked device information.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Device'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_device_list(self) -> dict[str, object] | str:
+        """
+        List SmartBlock blocked devices.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of blocked devices.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Device'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_device_delete(self, devices: list[str]) -> dict[str, object] | str:
+        """
+        Remove devices from the SmartBlock blocked list.
+
+        Parameters
+        ----------
+        devices : list[str]
+            List of device identifiers to remove.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the delete operation.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Device'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'delete',
+            'devices': json.dumps(devices),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.SmartBlock.Trusted
+    # ------------------------------------------------------------------
+
+    def smartblock_trusted_get(self) -> dict[str, object] | str:
+        """
+        Get SmartBlock trusted list.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Trusted list entries.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Trusted'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_trusted_list(self) -> dict[str, object] | str:
+        """
+        List SmartBlock trusted entries.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of trusted entries.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Trusted'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_trusted_set(self, entries: list[dict[str, object]]) -> dict[str, object] | str:
+        """
+        Set SmartBlock trusted list entries.
+
+        Parameters
+        ----------
+        entries : list[dict[str, object]]
+            List of trusted entry objects to set.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Trusted'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'set',
+            'entries': json.dumps(entries),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_trusted_delete(self, entries: list[str]) -> dict[str, object] | str:
+        """
+        Delete entries from the SmartBlock trusted list.
+
+        Parameters
+        ----------
+        entries : list[str]
+            List of entry identifiers to remove.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the delete operation.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Trusted'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'delete',
+            'entries': json.dumps(entries),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.SmartBlock.Untrusted
+    # ------------------------------------------------------------------
+
+    def smartblock_untrusted_get(self) -> dict[str, object] | str:
+        """
+        Get SmartBlock untrusted list.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Untrusted list entries.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Untrusted'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_untrusted_list(self) -> dict[str, object] | str:
+        """
+        List SmartBlock untrusted entries.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of untrusted entries.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Untrusted'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_untrusted_set(self, entries: list[dict[str, object]]) -> dict[str, object] | str:
+        """
+        Set SmartBlock untrusted list entries.
+
+        Parameters
+        ----------
+        entries : list[dict[str, object]]
+            List of untrusted entry objects to set.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Untrusted'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'set',
+            'entries': json.dumps(entries),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_untrusted_delete(self, entries: list[str]) -> dict[str, object] | str:
+        """
+        Delete entries from the SmartBlock untrusted list.
+
+        Parameters
+        ----------
+        entries : list[str]
+            List of entry identifiers to remove.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the delete operation.
+        """
+        api_name = 'SYNO.Core.SmartBlock.Untrusted'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'delete',
+            'entries': json.dumps(entries),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.SmartBlock.User
+    # ------------------------------------------------------------------
+
+    def smartblock_user_get(self) -> dict[str, object] | str:
+        """
+        Get SmartBlock user-level block settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            User-level block settings.
+        """
+        api_name = 'SYNO.Core.SmartBlock.User'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_user_list(self) -> dict[str, object] | str:
+        """
+        List SmartBlock user-level blocks.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of user-level blocks.
+        """
+        api_name = 'SYNO.Core.SmartBlock.User'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_user_set(self, users: list[dict[str, object]]) -> dict[str, object] | str:
+        """
+        Set SmartBlock user-level blocks.
+
+        Parameters
+        ----------
+        users : list[dict[str, object]]
+            List of user block objects to set.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.SmartBlock.User'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'set',
+            'users': json.dumps(users),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def smartblock_user_delete(self, users: list[str]) -> dict[str, object] | str:
+        """
+        Delete SmartBlock user-level blocks.
+
+        Parameters
+        ----------
+        users : list[str]
+            List of user identifiers to unblock.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the delete operation.
+        """
+        api_name = 'SYNO.Core.SmartBlock.User'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'delete',
+            'users': json.dumps(users),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.OTP
+    # ------------------------------------------------------------------
+
+    def otp_get(self) -> dict[str, object] | str:
+        """
+        Get OTP settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            OTP settings.
+        """
+        api_name = 'SYNO.Core.OTP'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def otp_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set OTP settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of OTP settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.OTP'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.OTP.Admin
+    # ------------------------------------------------------------------
+
+    def otp_admin_get(self) -> dict[str, object] | str:
+        """
+        Get OTP admin settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            OTP admin settings.
+        """
+        api_name = 'SYNO.Core.OTP.Admin'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def otp_admin_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set OTP admin settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of OTP admin settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.OTP.Admin'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.OTP.EnforcePolicy
+    # ------------------------------------------------------------------
+
+    def otp_enforce_policy_get(self) -> dict[str, object] | str:
+        """
+        Get OTP enforcement policy.
+
+        Returns
+        -------
+        dict[str, object] or str
+            OTP enforcement policy settings.
+        """
+        api_name = 'SYNO.Core.OTP.EnforcePolicy'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def otp_enforce_policy_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set OTP enforcement policy.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of enforcement policy settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.OTP.EnforcePolicy'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.OTP.Ex
+    # ------------------------------------------------------------------
+
+    def otp_ex_get(self) -> dict[str, object] | str:
+        """
+        Get extended OTP settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Extended OTP settings.
+        """
+        api_name = 'SYNO.Core.OTP.Ex'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def otp_ex_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set extended OTP settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of extended OTP settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.OTP.Ex'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.OTP.Mail
+    # ------------------------------------------------------------------
+
+    def otp_mail_get(self) -> dict[str, object] | str:
+        """
+        Get OTP mail settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            OTP mail settings.
+        """
+        api_name = 'SYNO.Core.OTP.Mail'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def otp_mail_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set OTP mail settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of OTP mail settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.OTP.Mail'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.TrustDevice
+    # ------------------------------------------------------------------
+
+    def trust_device_get(self) -> dict[str, object] | str:
+        """
+        Get trusted device settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Trusted device settings.
+        """
+        api_name = 'SYNO.Core.TrustDevice'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def trust_device_list(self) -> dict[str, object] | str:
+        """
+        List trusted devices.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of trusted devices.
+        """
+        api_name = 'SYNO.Core.TrustDevice'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'list'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def trust_device_delete(self, devices: list[str]) -> dict[str, object] | str:
+        """
+        Remove devices from the trusted list.
+
+        Parameters
+        ----------
+        devices : list[str]
+            List of device identifiers to remove.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the delete operation.
+        """
+        api_name = 'SYNO.Core.TrustDevice'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'delete',
+            'devices': json.dumps(devices),
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.DisableAdmin
+    # ------------------------------------------------------------------
+
+    def disable_admin_get(self) -> dict[str, object] | str:
+        """
+        Get disabled admin account settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Disabled admin account settings.
+        """
+        api_name = 'SYNO.Core.DisableAdmin'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def disable_admin_set(self, **kwargs: object) -> dict[str, object] | str:
+        """
+        Set disabled admin account settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Key-value pairs of admin disable settings to update.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Core.DisableAdmin'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)

--- a/tests/test_core_security_auth.py
+++ b/tests/test_core_security_auth.py
@@ -1,0 +1,171 @@
+"""Unit tests for core_security — verifies all API namespaces are covered."""
+
+import inspect
+import unittest
+from unittest.mock import MagicMock, patch
+
+from synology_api.core_security_auth import CoreSecurityAuth
+
+
+def _make_instance():
+    """Create a CoreSecurityAuth instance with mocked auth/session."""
+    with patch('synology_api.core_security_auth.base_api.BaseApi.__init__', return_value=None):
+        instance = CoreSecurityAuth.__new__(CoreSecurityAuth)
+
+    api_list = {
+        'SYNO.Core.SmartBlock': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.SmartBlock.Device': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.SmartBlock.Trusted': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.SmartBlock.Untrusted': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.SmartBlock.User': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.OTP': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.OTP.Admin': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.OTP.EnforcePolicy': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.OTP.Ex': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.OTP.Mail': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.TrustDevice': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.DisableAdmin': {'path': 'entry.cgi', 'maxVersion': 1},
+    }
+    instance.gen_list = api_list
+    instance.request_data = MagicMock(
+        return_value={'success': True, 'data': {}})
+    return instance
+
+
+class TestCoreSecurityAuth(unittest.TestCase):
+    """Tests for CoreSecurityAuth methods."""
+
+    def setUp(self):
+        self.instance = _make_instance()
+
+    def test_disable_admin_get(self):
+        self.instance.disable_admin_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_disable_admin_set(self):
+        self.instance.disable_admin_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_admin_get(self):
+        self.instance.otp_admin_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_admin_set(self):
+        self.instance.otp_admin_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_enforce_policy_get(self):
+        self.instance.otp_enforce_policy_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_enforce_policy_set(self):
+        self.instance.otp_enforce_policy_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_ex_get(self):
+        self.instance.otp_ex_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_ex_set(self):
+        self.instance.otp_ex_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_get(self):
+        self.instance.otp_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_mail_get(self):
+        self.instance.otp_mail_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_mail_set(self):
+        self.instance.otp_mail_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_otp_set(self):
+        self.instance.otp_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_device_delete(self):
+        self.instance.smartblock_device_delete(devices='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_device_get(self):
+        self.instance.smartblock_device_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_device_list(self):
+        self.instance.smartblock_device_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_get(self):
+        self.instance.smartblock_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_set(self):
+        self.instance.smartblock_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_trusted_delete(self):
+        self.instance.smartblock_trusted_delete(entries='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_trusted_get(self):
+        self.instance.smartblock_trusted_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_trusted_list(self):
+        self.instance.smartblock_trusted_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_trusted_set(self):
+        self.instance.smartblock_trusted_set(entries='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_untrusted_delete(self):
+        self.instance.smartblock_untrusted_delete(entries='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_untrusted_get(self):
+        self.instance.smartblock_untrusted_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_untrusted_list(self):
+        self.instance.smartblock_untrusted_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_untrusted_set(self):
+        self.instance.smartblock_untrusted_set(entries='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_user_delete(self):
+        self.instance.smartblock_user_delete(users='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_user_get(self):
+        self.instance.smartblock_user_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_user_list(self):
+        self.instance.smartblock_user_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_smartblock_user_set(self):
+        self.instance.smartblock_user_set(users='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_trust_device_delete(self):
+        self.instance.trust_device_delete(devices='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_trust_device_get(self):
+        self.instance.trust_device_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_trust_device_list(self):
+        self.instance.trust_device_list()
+        self.instance.request_data.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `CoreSecurityAuth` for SmartBlock, OTP, TrustDevice, and DisableAdmin DSM Core auth/security endpoints
- register the module in `synology_api.__init__` and `docs_status.yaml`
- add request-construction unit coverage for the new wrapper

## Verification
- `PYTHONPATH=tests .venv/bin/python -m pytest tests/test_core_security_auth.py -q`
- `pre-commit run --all-files`
- `.venv/bin/python -m scripts.docs_parser -a -l --exit-on-warning`
- `cd documentation && npm ci && npm run build`
