### PR TITLE
feat: add CoreServiceHW API coverage

### DIFF
--- a/docs_status.yaml
+++ b/docs_status.yaml
@@ -31,6 +31,8 @@ CoreNetwork:
     status: partial
 CoreSecurity:
     status: partial
+CoreServiceHW:
+    status: partial
 CoreStorage:
     status: partial
 CoreSystem:

--- a/synology_api/__init__.py
+++ b/synology_api/__init__.py
@@ -19,6 +19,7 @@ from . import \
     core_notification, \
     core_package, \
     core_security, \
+    core_service_hw, \
     core_share, \
     core_storage, \
     core_sys_info, \

--- a/synology_api/core_service_hw.py
+++ b/synology_api/core_service_hw.py
@@ -1,0 +1,1013 @@
+"""Synology Core hardware/media/package service API (SYNO.Core.*)."""
+
+from __future__ import annotations
+import json
+from typing import Optional
+from . import base_api
+
+
+class CoreServiceHW(base_api.BaseApi):
+    """Core hardware/media/package: Group, Hardware, ISCSI, Media, OAuth, Package, PortFwd."""
+
+    # SYNO.Core.Group extras
+    # ------------------------------------------------------------------
+
+    def group_extra_admin_get(self) -> dict[str, object] | str:
+        """
+        Get extra admin group settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the group extra admin get operation.
+        """
+        api_name = 'SYNO.Core.Group.ExtraAdmin'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def group_member_list(self, group: str) -> dict[str, object] | str:
+        """
+        List members of a group.
+
+        Parameters
+        ----------
+        group : str
+            The group value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the group member list operation.
+        """
+        api_name = 'SYNO.Core.Group.Member'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'list', 'group': group})
+
+    def group_valid_local_admin_get(self) -> dict[str, object] | str:
+        """
+        Get valid local admin information.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the group valid local admin get operation.
+        """
+        api_name = 'SYNO.Core.Group.ValidLocalAdmin'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Hardware extras
+    # ------------------------------------------------------------------
+
+    def hardware_lcm_get(self) -> dict[str, object] | str:
+        """
+        Get LCD monitor panel settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware lcm get operation.
+        """
+        api_name = 'SYNO.Core.Hardware.LCM'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def hardware_led_brightness_get(self) -> dict[str, object] | str:
+        """
+        Get LED brightness settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware led brightness get operation.
+        """
+        api_name = 'SYNO.Core.Hardware.Led.Brightness'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def hardware_led_brightness_set(self, brightness: int) -> dict[str, object] | str:
+        """
+        Set LED brightness level.
+
+        Parameters
+        ----------
+        brightness : int
+            The brightness value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware led brightness set operation.
+        """
+        api_name = 'SYNO.Core.Hardware.Led.Brightness'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'set',
+                                  'brightness': brightness})
+
+    def hardware_memory_layout_get(self) -> dict[str, object] | str:
+        """
+        Get memory layout information.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware memory layout get operation.
+        """
+        api_name = 'SYNO.Core.Hardware.MemoryLayout'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def hardware_need_reboot_get(self) -> dict[str, object] | str:
+        """
+        Check if a reboot is required.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware need reboot get operation.
+        """
+        api_name = 'SYNO.Core.Hardware.NeedReboot'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def hardware_oob_management_get(self) -> dict[str, object] | str:
+        """
+        Get out-of-band management (IPMI/BMC) settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware oob management get operation.
+        """
+        api_name = 'SYNO.Core.Hardware.OOBManagement'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def hardware_remote_fan_status_get(self) -> dict[str, object] | str:
+        """
+        Get remote fan status.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware remote fan status get operation.
+        """
+        api_name = 'SYNO.Core.Hardware.RemoteFanStatus'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def hardware_spectre_meltdown_get(self) -> dict[str, object] | str:
+        """
+        Get Spectre/Meltdown mitigation status.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware spectre meltdown get operation.
+        """
+        api_name = 'SYNO.Core.Hardware.SpectreMeltdown'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def hardware_video_transcoding_get(self) -> dict[str, object] | str:
+        """
+        Get hardware video transcoding capability.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the hardware video transcoding get operation.
+        """
+        api_name = 'SYNO.Core.Hardware.VideoTranscoding'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.ISCSI extras
+    # ------------------------------------------------------------------
+
+    def iscsi_fc_target_get(self) -> dict[str, object] | str:
+        """
+        Get Fibre Channel target settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the iscsi fc target get operation.
+        """
+        api_name = 'SYNO.Core.ISCSI.FCTarget'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def iscsi_host_get(self) -> dict[str, object] | str:
+        """
+        Get iSCSI host settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the iscsi host get operation.
+        """
+        api_name = 'SYNO.Core.ISCSI.Host'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def iscsi_lunbkp_get(self) -> dict[str, object] | str:
+        """
+        Get iSCSI LUN backup settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the iscsi lunbkp get operation.
+        """
+        api_name = 'SYNO.Core.ISCSI.Lunbkp'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def iscsi_node_get(self) -> dict[str, object] | str:
+        """
+        Get iSCSI node information.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the iscsi node get operation.
+        """
+        api_name = 'SYNO.Core.ISCSI.Node'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def iscsi_replication_get(self) -> dict[str, object] | str:
+        """
+        Get iSCSI replication settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the iscsi replication get operation.
+        """
+        api_name = 'SYNO.Core.ISCSI.Replication'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def iscsi_vmware_get(self) -> dict[str, object] | str:
+        """
+        Get iSCSI VMware integration settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the iscsi vmware get operation.
+        """
+        api_name = 'SYNO.Core.ISCSI.VMware'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.MediaIndexing
+    # ------------------------------------------------------------------
+
+    def media_indexing_get(self) -> dict[str, object] | str:
+        """
+        Get media indexing settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the media indexing get operation.
+        """
+        api_name = 'SYNO.Core.MediaIndexing'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def media_indexing_set(self, **kwargs) -> dict[str, object] | str:
+        """
+        Set media indexing settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Additional DSM API parameters for the set operation.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the media indexing set operation.
+        """
+        api_name = 'SYNO.Core.MediaIndexing'
+        info = self.gen_list[api_name]
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        req_param.update(kwargs)
+        return self.request_data(api_name, info['path'], req_param)
+
+    def media_indexing_index_folder_get(self) -> dict[str, object] | str:
+        """
+        Get indexed folder list.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the media indexing index folder get operation.
+        """
+        api_name = 'SYNO.Core.MediaIndexing.IndexFolder'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def media_indexing_media_converter_get(self) -> dict[str, object] | str:
+        """
+        Get media converter settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the media indexing media converter get operation.
+        """
+        api_name = 'SYNO.Core.MediaIndexing.MediaConverter'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def media_indexing_scheduler_get(self) -> dict[str, object] | str:
+        """
+        Get media indexing scheduler settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the media indexing scheduler get operation.
+        """
+        api_name = 'SYNO.Core.MediaIndexing.Scheduler'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def media_indexing_thumbnail_quality_get(self) -> dict[str, object] | str:
+        """
+        Get thumbnail quality settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the media indexing thumbnail quality get operation.
+        """
+        api_name = 'SYNO.Core.MediaIndexing.ThumbnailQuality'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.MyDSCenter
+    # ------------------------------------------------------------------
+
+    def mydscenter_get(self) -> dict[str, object] | str:
+        """
+        Get MyDS Center settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the mydscenter get operation.
+        """
+        api_name = 'SYNO.Core.MyDSCenter'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def mydscenter_account_get(self) -> dict[str, object] | str:
+        """
+        Get MyDS Center account information.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the mydscenter account get operation.
+        """
+        api_name = 'SYNO.Core.MyDSCenter.Account'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def mydscenter_login(self, username: str, password: str) -> dict[str, object] | str:
+        """
+        Login to MyDS Center.
+
+        Parameters
+        ----------
+        username : str
+            The username value.
+        password : str
+            The password value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the mydscenter login operation.
+        """
+        api_name = 'SYNO.Core.MyDSCenter.Login'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'login',
+                                  'username': username, 'password': password}, method='post')
+
+    def mydscenter_logout(self) -> dict[str, object] | str:
+        """
+        Logout from MyDS Center.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the mydscenter logout operation.
+        """
+        api_name = 'SYNO.Core.MyDSCenter.Logout'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'logout'})
+
+    def mydscenter_purchase_get(self) -> dict[str, object] | str:
+        """
+        Get MyDS Center purchase information.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the mydscenter purchase get operation.
+        """
+        api_name = 'SYNO.Core.MyDSCenter.Purchase'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.NormalUser
+    # ------------------------------------------------------------------
+
+    def normal_user_get(self) -> dict[str, object] | str:
+        """
+        Get normal user settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the normal user get operation.
+        """
+        api_name = 'SYNO.Core.NormalUser'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def normal_user_login_notify_get(self) -> dict[str, object] | str:
+        """
+        Get normal user login notification settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the normal user login notify get operation.
+        """
+        api_name = 'SYNO.Core.NormalUser.LoginNotify'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.OAuth
+    # ------------------------------------------------------------------
+
+    def oauth_scope_get(self) -> dict[str, object] | str:
+        """
+        Get OAuth scope settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the oauth scope get operation.
+        """
+        api_name = 'SYNO.Core.OAuth.Scope'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def oauth_server_get(self) -> dict[str, object] | str:
+        """
+        Get OAuth server settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the oauth server get operation.
+        """
+        api_name = 'SYNO.Core.OAuth.Server'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def oauth_server_set(self, **kwargs) -> dict[str, object] | str:
+        """
+        Set OAuth server settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Additional DSM API parameters for the set operation.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the oauth server set operation.
+        """
+        api_name = 'SYNO.Core.OAuth.Server'
+        info = self.gen_list[api_name]
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        req_param.update(kwargs)
+        return self.request_data(api_name, info['path'], req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.Package extras
+    # ------------------------------------------------------------------
+
+    def package_auto_upgrade_progress_get(self) -> dict[str, object] | str:
+        """
+        Get package auto-upgrade progress.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package auto upgrade progress get operation.
+        """
+        api_name = 'SYNO.Core.Package.AutoUpgrade.Progress'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def package_control(self, package_id: str, action: str) -> dict[str, object] | str:
+        """
+        Control a package (start/stop).
+
+        Parameters
+        ----------
+        package_id : str
+            The package id value.
+        action : str
+            The action value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package control operation.
+        """
+        api_name = 'SYNO.Core.Package.Control'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': action, 'id': package_id})
+
+    def package_fake_iframe_get(self) -> dict[str, object] | str:
+        """
+        Get package fake iframe info.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package fake iframe get operation.
+        """
+        api_name = 'SYNO.Core.Package.FakeIFrame'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def package_feed_list(self) -> dict[str, object] | str:
+        """
+        List package feeds.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package feed list operation.
+        """
+        api_name = 'SYNO.Core.Package.Feed'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'list'})
+
+    def package_feed_set(self, **kwargs) -> dict[str, object] | str:
+        """
+        Set package feed settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Additional DSM API parameters for the set operation.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package feed set operation.
+        """
+        api_name = 'SYNO.Core.Package.Feed'
+        info = self.gen_list[api_name]
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        req_param.update(kwargs)
+        return self.request_data(api_name, info['path'], req_param)
+
+    def package_legal_prerelease_get(self) -> dict[str, object] | str:
+        """
+        Get package pre-release legal agreement status.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package legal prerelease get operation.
+        """
+        api_name = 'SYNO.Core.Package.Legal.PreRelease'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def package_log_get(self, package_id: Optional[str] = None) -> dict[str, object] | str:
+        """
+        Get package log entries.
+
+        Parameters
+        ----------
+        package_id : str, optional
+            The package id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package log get operation.
+        """
+        api_name = 'SYNO.Core.Package.Log'
+        info = self.gen_list[api_name]
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+        if package_id:
+            req_param['id'] = package_id
+        return self.request_data(api_name, info['path'], req_param)
+
+    def package_myds_get(self) -> dict[str, object] | str:
+        """
+        Get MyDS package info.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package myds get operation.
+        """
+        api_name = 'SYNO.Core.Package.MyDS'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def package_myds_purchase_get(self) -> dict[str, object] | str:
+        """
+        Get MyDS package purchase info.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package myds purchase get operation.
+        """
+        api_name = 'SYNO.Core.Package.MyDS.Purchase'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def package_progress_get(self, task_id: Optional[str] = None) -> dict[str, object] | str:
+        """
+        Get package installation/upgrade progress.
+
+        Parameters
+        ----------
+        task_id : str, optional
+            The task id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package progress get operation.
+        """
+        api_name = 'SYNO.Core.Package.Progress'
+        info = self.gen_list[api_name]
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+        if task_id:
+            req_param['taskid'] = task_id
+        return self.request_data(api_name, info['path'], req_param)
+
+    def package_screenshot_get(self, package_id: str) -> dict[str, object] | str:
+        """
+        Get package screenshots.
+
+        Parameters
+        ----------
+        package_id : str
+            The package id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package screenshot get operation.
+        """
+        api_name = 'SYNO.Core.Package.Screenshot'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get', 'id': package_id})
+
+    def package_screenshot_server_get(self, package_id: str) -> dict[str, object] | str:
+        """
+        Get package screenshot from server.
+
+        Parameters
+        ----------
+        package_id : str
+            The package id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package screenshot server get operation.
+        """
+        api_name = 'SYNO.Core.Package.Screenshot.Server'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get', 'id': package_id})
+
+    def package_setting_update_get(self) -> dict[str, object] | str:
+        """
+        Get package update settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package setting update get operation.
+        """
+        api_name = 'SYNO.Core.Package.Setting.Update'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def package_thumb_get(self, package_id: str) -> dict[str, object] | str:
+        """
+        Get package thumbnail.
+
+        Parameters
+        ----------
+        package_id : str
+            The package id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package thumb get operation.
+        """
+        api_name = 'SYNO.Core.Package.Thumb'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get', 'id': package_id})
+
+    def package_thumb_server_get(self, package_id: str) -> dict[str, object] | str:
+        """
+        Get package thumbnail from server.
+
+        Parameters
+        ----------
+        package_id : str
+            The package id value.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the package thumb server get operation.
+        """
+        api_name = 'SYNO.Core.Package.Thumb.Server'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get', 'id': package_id})
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.PersonalNotification
+    # ------------------------------------------------------------------
+
+    def personal_notification_device_get(self) -> dict[str, object] | str:
+        """
+        Get personal notification device settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the personal notification device get operation.
+        """
+        api_name = 'SYNO.Core.PersonalNotification.Device'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def personal_notification_event_get(self) -> dict[str, object] | str:
+        """
+        Get personal notification events.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the personal notification event get operation.
+        """
+        api_name = 'SYNO.Core.PersonalNotification.Event'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def personal_notification_filter_get(self) -> dict[str, object] | str:
+        """
+        Get personal notification filter settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the personal notification filter get operation.
+        """
+        api_name = 'SYNO.Core.PersonalNotification.Filter'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def personal_notification_filter_set(self, **kwargs) -> dict[str, object] | str:
+        """
+        Set personal notification filter settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Additional DSM API parameters for the set operation.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the personal notification filter set operation.
+        """
+        api_name = 'SYNO.Core.PersonalNotification.Filter'
+        info = self.gen_list[api_name]
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        req_param.update(kwargs)
+        return self.request_data(api_name, info['path'], req_param)
+
+    def personal_notification_mobile_get(self) -> dict[str, object] | str:
+        """
+        Get personal notification mobile settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the personal notification mobile get operation.
+        """
+        api_name = 'SYNO.Core.PersonalNotification.Mobile'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def personal_notification_settings_get(self) -> dict[str, object] | str:
+        """
+        Get personal notification settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the personal notification settings get operation.
+        """
+        api_name = 'SYNO.Core.PersonalNotification.Settings'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def personal_notification_settings_set(self, **kwargs) -> dict[str, object] | str:
+        """
+        Set personal notification settings.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Additional DSM API parameters for the set operation.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the personal notification settings set operation.
+        """
+        api_name = 'SYNO.Core.PersonalNotification.Settings'
+        info = self.gen_list[api_name]
+        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        req_param.update(kwargs)
+        return self.request_data(api_name, info['path'], req_param)
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.PhotoViewer
+    # ------------------------------------------------------------------
+
+    def photo_viewer_get(self) -> dict[str, object] | str:
+        """
+        Get photo viewer settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the photo viewer get operation.
+        """
+        api_name = 'SYNO.Core.PhotoViewer'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    # ------------------------------------------------------------------
+    # SYNO.Core.PortForwarding extras
+    # ------------------------------------------------------------------
+
+    def port_forwarding_get(self) -> dict[str, object] | str:
+        """
+        Get port forwarding settings.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the port forwarding get operation.
+        """
+        api_name = 'SYNO.Core.PortForwarding'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def port_forwarding_compatibility_get(self) -> dict[str, object] | str:
+        """
+        Get port forwarding compatibility status.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the port forwarding compatibility get operation.
+        """
+        api_name = 'SYNO.Core.PortForwarding.Compatibility'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def port_forwarding_router_info_get(self) -> dict[str, object] | str:
+        """
+        Get router information for port forwarding.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the port forwarding router info get operation.
+        """
+        api_name = 'SYNO.Core.PortForwarding.RouterInfo'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def port_forwarding_router_list(self) -> dict[str, object] | str:
+        """
+        List detected routers.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the port forwarding router list operation.
+        """
+        api_name = 'SYNO.Core.PortForwarding.RouterList'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    def port_forwarding_rules_serv_get(self) -> dict[str, object] | str:
+        """
+        Get service-based port forwarding rules.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the port forwarding rules serv get operation.
+        """
+        api_name = 'SYNO.Core.PortForwarding.Rules.Serv'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'get'})
+
+    # ------------------------------------------------------------------

--- a/tests/test_core_service_hw.py
+++ b/tests/test_core_service_hw.py
@@ -1,0 +1,335 @@
+"""Unit tests for core_service — verifies all API namespaces are covered."""
+
+import inspect
+import unittest
+from unittest.mock import MagicMock, patch
+
+from synology_api.core_service_hw import CoreServiceHW
+
+
+def _make_instance():
+    """Create a CoreServiceHW instance with mocked auth/session."""
+    with patch('synology_api.core_service_hw.base_api.BaseApi.__init__', return_value=None):
+        instance = CoreServiceHW.__new__(CoreServiceHW)
+
+    api_list = {
+        'SYNO.Core.Group.ExtraAdmin': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Group.Member': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Group.ValidLocalAdmin': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Hardware.LCM': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Hardware.Led.Brightness': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Hardware.MemoryLayout': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Hardware.NeedReboot': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Hardware.OOBManagement': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Hardware.RemoteFanStatus': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Hardware.SpectreMeltdown': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Hardware.VideoTranscoding': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ISCSI.FCTarget': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ISCSI.Host': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ISCSI.Lunbkp': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ISCSI.Node': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ISCSI.Replication': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.ISCSI.VMware': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MediaIndexing': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MediaIndexing.IndexFolder': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MediaIndexing.MediaConverter': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MediaIndexing.Scheduler': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MediaIndexing.ThumbnailQuality': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MyDSCenter': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MyDSCenter.Account': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MyDSCenter.Login': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MyDSCenter.Logout': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.MyDSCenter.Purchase': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.NormalUser': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.NormalUser.LoginNotify': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.OAuth.Scope': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.OAuth.Server': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.AutoUpgrade.Progress': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Control': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.FakeIFrame': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Feed': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Legal.PreRelease': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Log': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.MyDS': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.MyDS.Purchase': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Progress': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Screenshot': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Screenshot.Server': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Setting.Update': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Thumb': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.Package.Thumb.Server': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PersonalNotification.Device': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PersonalNotification.Event': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PersonalNotification.Filter': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PersonalNotification.Mobile': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PersonalNotification.Settings': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PhotoViewer': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PortForwarding': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PortForwarding.Compatibility': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PortForwarding.RouterInfo': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PortForwarding.RouterList': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.Core.PortForwarding.Rules.Serv': {'path': 'entry.cgi', 'maxVersion': 1},
+    }
+    instance.gen_list = api_list
+    instance.request_data = MagicMock(
+        return_value={'success': True, 'data': {}})
+    return instance
+
+
+class TestCoreServiceHW(unittest.TestCase):
+    """Tests for CoreServiceHW methods."""
+
+    def setUp(self):
+        self.instance = _make_instance()
+
+    def test_group_extra_admin_get(self):
+        self.instance.group_extra_admin_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_group_member_list(self):
+        self.instance.group_member_list(group='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_group_valid_local_admin_get(self):
+        self.instance.group_valid_local_admin_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_lcm_get(self):
+        self.instance.hardware_lcm_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_led_brightness_get(self):
+        self.instance.hardware_led_brightness_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_led_brightness_set(self):
+        self.instance.hardware_led_brightness_set(brightness=1)
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_memory_layout_get(self):
+        self.instance.hardware_memory_layout_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_need_reboot_get(self):
+        self.instance.hardware_need_reboot_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_oob_management_get(self):
+        self.instance.hardware_oob_management_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_remote_fan_status_get(self):
+        self.instance.hardware_remote_fan_status_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_spectre_meltdown_get(self):
+        self.instance.hardware_spectre_meltdown_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_hardware_video_transcoding_get(self):
+        self.instance.hardware_video_transcoding_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_iscsi_fc_target_get(self):
+        self.instance.iscsi_fc_target_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_iscsi_host_get(self):
+        self.instance.iscsi_host_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_iscsi_lunbkp_get(self):
+        self.instance.iscsi_lunbkp_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_iscsi_node_get(self):
+        self.instance.iscsi_node_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_iscsi_replication_get(self):
+        self.instance.iscsi_replication_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_iscsi_vmware_get(self):
+        self.instance.iscsi_vmware_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_media_indexing_get(self):
+        self.instance.media_indexing_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_media_indexing_index_folder_get(self):
+        self.instance.media_indexing_index_folder_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_media_indexing_media_converter_get(self):
+        self.instance.media_indexing_media_converter_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_media_indexing_scheduler_get(self):
+        self.instance.media_indexing_scheduler_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_media_indexing_set(self):
+        self.instance.media_indexing_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_media_indexing_thumbnail_quality_get(self):
+        self.instance.media_indexing_thumbnail_quality_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_mydscenter_account_get(self):
+        self.instance.mydscenter_account_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_mydscenter_get(self):
+        self.instance.mydscenter_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_mydscenter_login(self):
+        self.instance.mydscenter_login(username='test', password='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_mydscenter_logout(self):
+        self.instance.mydscenter_logout()
+        self.instance.request_data.assert_called_once()
+
+    def test_mydscenter_purchase_get(self):
+        self.instance.mydscenter_purchase_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_normal_user_get(self):
+        self.instance.normal_user_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_normal_user_login_notify_get(self):
+        self.instance.normal_user_login_notify_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_oauth_scope_get(self):
+        self.instance.oauth_scope_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_oauth_server_get(self):
+        self.instance.oauth_server_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_oauth_server_set(self):
+        self.instance.oauth_server_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_auto_upgrade_progress_get(self):
+        self.instance.package_auto_upgrade_progress_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_control(self):
+        self.instance.package_control(package_id='test', action='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_package_fake_iframe_get(self):
+        self.instance.package_fake_iframe_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_feed_list(self):
+        self.instance.package_feed_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_feed_set(self):
+        self.instance.package_feed_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_legal_prerelease_get(self):
+        self.instance.package_legal_prerelease_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_log_get(self):
+        self.instance.package_log_get(package_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_package_myds_get(self):
+        self.instance.package_myds_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_myds_purchase_get(self):
+        self.instance.package_myds_purchase_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_progress_get(self):
+        self.instance.package_progress_get(task_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_package_screenshot_get(self):
+        self.instance.package_screenshot_get(package_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_package_screenshot_server_get(self):
+        self.instance.package_screenshot_server_get(package_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_package_setting_update_get(self):
+        self.instance.package_setting_update_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_package_thumb_get(self):
+        self.instance.package_thumb_get(package_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_package_thumb_server_get(self):
+        self.instance.package_thumb_server_get(package_id='test')
+        self.instance.request_data.assert_called_once()
+
+    def test_personal_notification_device_get(self):
+        self.instance.personal_notification_device_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_personal_notification_event_get(self):
+        self.instance.personal_notification_event_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_personal_notification_filter_get(self):
+        self.instance.personal_notification_filter_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_personal_notification_filter_set(self):
+        self.instance.personal_notification_filter_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_personal_notification_mobile_get(self):
+        self.instance.personal_notification_mobile_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_personal_notification_settings_get(self):
+        self.instance.personal_notification_settings_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_personal_notification_settings_set(self):
+        self.instance.personal_notification_settings_set()
+        self.instance.request_data.assert_called_once()
+
+    def test_photo_viewer_get(self):
+        self.instance.photo_viewer_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_port_forwarding_compatibility_get(self):
+        self.instance.port_forwarding_compatibility_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_port_forwarding_get(self):
+        self.instance.port_forwarding_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_port_forwarding_router_info_get(self):
+        self.instance.port_forwarding_router_info_get()
+        self.instance.request_data.assert_called_once()
+
+    def test_port_forwarding_router_list(self):
+        self.instance.port_forwarding_router_list()
+        self.instance.request_data.assert_called_once()
+
+    def test_port_forwarding_rules_serv_get(self):
+        self.instance.port_forwarding_rules_serv_get()
+        self.instance.request_data.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `CoreServiceHW` coverage for hardware/platform Core services including Group, Hardware, ISCSI, MediaIndexing, OAuth, Package feeds, PortForwarding, and personal notification settings
- register the module in `synology_api.__init__` and `docs_status.yaml`
- add request-construction unit coverage for the new wrapper

## Verification
- `PYTHONPATH=tests .venv/bin/python -m pytest tests/test_core_service_hw.py -q`
- `pre-commit run --all-files`
- `.venv/bin/python -m scripts.docs_parser -a -l --exit-on-warning`
- `cd documentation && npm ci && npm run build`
