### PR TITLE
Add AppPortal reverse proxy access control helpers

### DIFF
--- a/synology_api/core_service_apps.py
+++ b/synology_api/core_service_apps.py
@@ -8,7 +8,7 @@ core_storage, core_upgrade, core_system, or core_external_device modules.
 
 from __future__ import annotations
 import json
-from typing import Optional
+from typing import Optional, Sequence
 from . import base_api
 
 
@@ -182,6 +182,20 @@ class CoreServiceApps(base_api.BaseApi):
         return self.request_data(api_name, info['path'],
                                  {'version': info['maxVersion'], 'method': 'get'})
 
+    def app_portal_access_control_list(self) -> dict[str, object] | str:
+        """
+        List application portal access control entries.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the app portal access control list operation.
+        """
+        api_name = 'SYNO.Core.AppPortal.AccessControl'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'],
+                                 {'version': info['maxVersion'], 'method': 'list'})
+
     def app_portal_access_control_set(self, **kwargs) -> dict[str, object] | str:
         """
         Set application portal access control settings.
@@ -202,6 +216,49 @@ class CoreServiceApps(base_api.BaseApi):
         req_param.update(kwargs)
         return self.request_data(api_name, info['path'], req_param)
 
+    def app_portal_access_control_update(self, entry: dict[str, object] | str) -> dict[str, object] | str:
+        """
+        Update an application portal access control entry.
+
+        Parameters
+        ----------
+        entry : dict[str, object] or str
+            Access control entry to update. Dict values are JSON encoded before
+            they are sent to DSM.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the app portal access control update operation.
+        """
+        api_name = 'SYNO.Core.AppPortal.AccessControl'
+        info = self.gen_list[api_name]
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'update',
+            'entry': self._format_app_portal_entry(entry),
+        }
+        return self.request_data(api_name, info['path'], req_param)
+
+    @staticmethod
+    def _format_app_portal_entry(entry: dict[str, object] | str) -> str:
+        """
+        Format an AppPortal entry payload for DSM.
+
+        Parameters
+        ----------
+        entry : dict[str, object] or str
+            Entry payload as a Python dictionary or pre-encoded JSON string.
+
+        Returns
+        -------
+        str
+            JSON string to send to DSM.
+        """
+        if isinstance(entry, str):
+            return entry
+        return json.dumps(entry, separators=(',', ':'))
+
     def app_portal_config_get(self) -> dict[str, object] | str:
         """
         Get application portal configuration.
@@ -218,35 +275,121 @@ class CoreServiceApps(base_api.BaseApi):
 
     def app_portal_reverse_proxy_get(self) -> dict[str, object] | str:
         """
-        Get reverse proxy rules for app portal.
+        List reverse proxy rules for app portal.
 
         Returns
         -------
         dict[str, object] or str
-            Result of the app portal reverse proxy get operation.
+            Result of the app portal reverse proxy list operation.
+        """
+        return self.app_portal_reverse_proxy_list()
+
+    def app_portal_reverse_proxy_list(self) -> dict[str, object] | str:
+        """
+        List reverse proxy rules for app portal.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the app portal reverse proxy list operation.
         """
         api_name = 'SYNO.Core.AppPortal.ReverseProxy'
         info = self.gen_list[api_name]
         return self.request_data(api_name, info['path'],
-                                 {'version': info['maxVersion'], 'method': 'get'})
+                                 {'version': info['maxVersion'], 'method': 'list'})
 
-    def app_portal_reverse_proxy_set(self, **kwargs) -> dict[str, object] | str:
+    def app_portal_reverse_proxy_create(self, entry: dict[str, object] | str) -> dict[str, object] | str:
         """
-        Set reverse proxy rules for app portal.
+        Create an app portal reverse proxy rule.
 
         Parameters
         ----------
-        **kwargs : object
-            Additional DSM API parameters for the set operation.
+        entry : dict[str, object] or str
+            Reverse proxy entry to create. Dict values are JSON encoded before
+            they are sent to DSM.
 
         Returns
         -------
         dict[str, object] or str
-            Result of the app portal reverse proxy set operation.
+            Result of the app portal reverse proxy create operation.
         """
         api_name = 'SYNO.Core.AppPortal.ReverseProxy'
         info = self.gen_list[api_name]
-        req_param = {'version': info['maxVersion'], 'method': 'set'}
+        return self.request_data(api_name, info['path'], {
+            'version': info['maxVersion'],
+            'method': 'create',
+            'entry': self._format_app_portal_entry(entry),
+        })
+
+    def app_portal_reverse_proxy_update(self, entry: dict[str, object] | str) -> dict[str, object] | str:
+        """
+        Update an app portal reverse proxy rule.
+
+        Parameters
+        ----------
+        entry : dict[str, object] or str
+            Reverse proxy entry to update. Dict values are JSON encoded before
+            they are sent to DSM.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the app portal reverse proxy update operation.
+        """
+        api_name = 'SYNO.Core.AppPortal.ReverseProxy'
+        info = self.gen_list[api_name]
+        return self.request_data(api_name, info['path'], {
+            'version': info['maxVersion'],
+            'method': 'update',
+            'entry': self._format_app_portal_entry(entry),
+        })
+
+    def app_portal_reverse_proxy_delete(self, uuids: str | Sequence[str]) -> dict[str, object] | str:
+        """
+        Delete app portal reverse proxy rules.
+
+        Parameters
+        ----------
+        uuids : str or Sequence[str]
+            Reverse proxy UUID or UUIDs to delete.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the app portal reverse proxy delete operation.
+        """
+        api_name = 'SYNO.Core.AppPortal.ReverseProxy'
+        info = self.gen_list[api_name]
+        if isinstance(uuids, str):
+            if uuids.lstrip().startswith('['):
+                uuids_payload = uuids
+            else:
+                uuids_payload = json.dumps([uuids], separators=(',', ':'))
+        else:
+            uuids_payload = json.dumps(list(uuids), separators=(',', ':'))
+        return self.request_data(api_name, info['path'], {
+            'version': info['maxVersion'],
+            'method': 'delete',
+            'uuids': uuids_payload,
+        })
+
+    def app_portal_reverse_proxy_set(self, **kwargs) -> dict[str, object] | str:
+        """
+        Update reverse proxy rules for app portal.
+
+        Parameters
+        ----------
+        **kwargs : object
+            Additional DSM API parameters for the update operation.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the app portal reverse proxy update operation.
+        """
+        api_name = 'SYNO.Core.AppPortal.ReverseProxy'
+        info = self.gen_list[api_name]
+        req_param = {'version': info['maxVersion'], 'method': 'update'}
         req_param.update(kwargs)
         return self.request_data(api_name, info['path'], req_param)
 

--- a/tests/test_core_service_apps.py
+++ b/tests/test_core_service_apps.py
@@ -100,9 +100,52 @@ class TestCoreServiceApps(unittest.TestCase):
         self.instance.app_portal_access_control_get()
         self.instance.request_data.assert_called_once()
 
+    def test_app_portal_access_control_list_request_contract(self):
+        self.instance.app_portal_access_control_list()
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.AccessControl',
+            'entry.cgi',
+            {'version': 1, 'method': 'list'},
+        )
+
     def test_app_portal_access_control_set(self):
         self.instance.app_portal_access_control_set()
         self.instance.request_data.assert_called_once()
+
+    def test_app_portal_access_control_update_serializes_entry(self):
+        entry = {
+            'UUID': 'rule-uuid',
+            '_key': 'rule-key',
+            'name': 'block',
+            'rules': [
+                {'access': True, 'address': '192.0.2.1'},
+                {'access': False, 'address': '198.51.100.2'},
+            ],
+        }
+        expected_entry = (
+            '{"UUID":"rule-uuid","_key":"rule-key","name":"block",'
+            '"rules":[{"access":true,"address":"192.0.2.1"},'
+            '{"access":false,"address":"198.51.100.2"}]}'
+        )
+
+        self.instance.app_portal_access_control_update(entry)
+
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.AccessControl',
+            'entry.cgi',
+            {'version': 1, 'method': 'update', 'entry': expected_entry},
+        )
+
+    def test_app_portal_access_control_update_accepts_preencoded_entry(self):
+        entry = '{"UUID":"rule-uuid","rules":[]}'
+
+        self.instance.app_portal_access_control_update(entry)
+
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.AccessControl',
+            'entry.cgi',
+            {'version': 1, 'method': 'update', 'entry': entry},
+        )
 
     def test_app_portal_config_get(self):
         self.instance.app_portal_config_get()
@@ -114,11 +157,78 @@ class TestCoreServiceApps(unittest.TestCase):
 
     def test_app_portal_reverse_proxy_get(self):
         self.instance.app_portal_reverse_proxy_get()
-        self.instance.request_data.assert_called_once()
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.ReverseProxy',
+            'entry.cgi',
+            {'version': 1, 'method': 'list'},
+        )
+
+    def test_app_portal_reverse_proxy_list_request_contract(self):
+        self.instance.app_portal_reverse_proxy_list()
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.ReverseProxy',
+            'entry.cgi',
+            {'version': 1, 'method': 'list'},
+        )
+
+    def test_app_portal_reverse_proxy_create_serializes_entry(self):
+        entry = {
+            'description': 'test',
+            'frontend': {'fqdn': 'test.local', 'port': 18080, 'protocol': 0, 'acl': None},
+            'backend': {'fqdn': '127.0.0.1', 'port': 80, 'protocol': 0},
+            'proxy_intercept_errors': False,
+        }
+        expected_entry = (
+            '{"description":"test","frontend":{"fqdn":"test.local",'
+            '"port":18080,"protocol":0,"acl":null},"backend":'
+            '{"fqdn":"127.0.0.1","port":80,"protocol":0},'
+            '"proxy_intercept_errors":false}'
+        )
+
+        self.instance.app_portal_reverse_proxy_create(entry)
+
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.ReverseProxy',
+            'entry.cgi',
+            {'version': 1, 'method': 'create', 'entry': expected_entry},
+        )
+
+    def test_app_portal_reverse_proxy_update_accepts_preencoded_entry(self):
+        entry = '{"UUID":"rule-uuid","description":"test"}'
+
+        self.instance.app_portal_reverse_proxy_update(entry)
+
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.ReverseProxy',
+            'entry.cgi',
+            {'version': 1, 'method': 'update', 'entry': entry},
+        )
+
+    def test_app_portal_reverse_proxy_delete_serializes_uuid_list(self):
+        self.instance.app_portal_reverse_proxy_delete(
+            ['rule-uuid-1', 'rule-uuid-2'])
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.ReverseProxy',
+            'entry.cgi',
+            {
+                'version': 1,
+                'method': 'delete',
+                'uuids': '["rule-uuid-1","rule-uuid-2"]',
+            },
+        )
 
     def test_app_portal_reverse_proxy_set(self):
-        self.instance.app_portal_reverse_proxy_set()
-        self.instance.request_data.assert_called_once()
+        self.instance.app_portal_reverse_proxy_set(
+            entry='{"UUID":"rule-uuid"}')
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Core.AppPortal.ReverseProxy',
+            'entry.cgi',
+            {
+                'version': 1,
+                'method': 'update',
+                'entry': '{"UUID":"rule-uuid"}',
+            },
+        )
 
     def test_app_portal_set(self):
         self.instance.app_portal_set()


### PR DESCRIPTION
## Summary
- add AppPortal AccessControl list/update helpers with JSON entry serialization
- fix ReverseProxy list handling and add create/update/delete helpers
- add request-contract coverage for AccessControl and ReverseProxy payloads

## Validation
- python -m pytest tests/test_core_service_apps.py -q
- PYTHONPATH=tests python -m pytest -q --ignore=tests/integration --ignore=tests/test_add_s3_sync_task.py --ignore=tests/test_core_user.py --ignore=tests/test_syno_api.py
- python -m compileall -q synology_api/core_service_apps.py tests/test_core_service_apps.py
- git diff --check
- live DSM add/remove smoke test for a temporary reverse proxy entry; final temp count returned to 0

Closes #179