### PR TITLE
Fix Synology Photos item listing contract

### DIFF
--- a/documentation/docs/apis/classes/photos.md
+++ b/documentation/docs/apis/classes/photos.md
@@ -565,7 +565,7 @@ The list of users and groups or an error message.
 
 
 ### `list_item_in_folders`
-List all items in all folders in Personal Space.  
+List items in a Personal Space folder.
   
 #### Internal API
 <div class="padding-left--md">
@@ -574,14 +574,14 @@ List all items in all folders in Personal Space.
   
 #### Parameters
 <div class="padding-left--md">
-**_offset_** `int`  
-Specify how many shared folders are skipped before beginning to return listed shared folders.  
-  
-**_limit_** `int`  
-Number of shared folders requested. Set to `0` to list all shared folders.  
-  
-**_folder_id_** `int`  
-ID of folder.  
+**_offset_** `int`
+Specify how many items are skipped before beginning to return listed items.
+
+**_limit_** `int`
+Number of items requested. Default is 1000.
+
+**_folder_id_** `int`
+ID of the folder returned by `list_folders`. Required by Synology Photos item listing.
   
 **_sort_by_** `str`  
 Possible values: 'filename', 'filesize', 'takentime', 'item_type'.  
@@ -614,8 +614,58 @@ The list of items or an error message.
 ---
 
 
+### `list_item_in_team_folders`
+List items in a Team Space folder.
+
+#### Internal API
+<div class="padding-left--md">
+`SYNO.FotoTeam.Browse.Item`
+</div>
+
+#### Parameters
+<div class="padding-left--md">
+**_offset_** `int`
+Specify how many items are skipped before beginning to return listed items.
+
+**_limit_** `int`
+Number of items requested. Default is 1000.
+
+**_folder_id_** `int`
+ID of the folder returned by `list_teams_folders`. Required by Synology Photos item listing.
+
+**_sort_by_** `str`
+Possible values: 'filename', 'filesize', 'takentime', 'item_type'.
+
+**_sort_direction_** `str`
+Possible values: 'asc' or 'desc'. Defaults to: 'desc'.
+
+**_type_** `str`
+Possible values: 'photo', 'video', 'live'.
+
+**_passphrase_** `str`
+Passphrase for a shared album.
+
+**_additional_** `list`
+Additional fields to include.
+Possible values:
+    `["thumbnail","resolution", "orientation", "video_convert", "video_meta", "provider_user_id", "exif", "tag", "description", "gps", "geocoding_id", "address", "person"]`.
+
+
+</div>
+#### Returns
+<div class="padding-left--md">
+`dict[str, object] or str`
+The list of team items or an error message.
+
+</div>
+
+
+
+---
+
+
 ### `list_search_filters`
-List available search filters.  
+List available search filters.
   
 #### Internal API
 <div class="padding-left--md">

--- a/synology_api/photos.py
+++ b/synology_api/photos.py
@@ -641,20 +641,21 @@ class Photos(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def list_item_in_folders(self, offset: int = 0, limit: int = 0, folder_id: int = 0, sort_by: str = 'filename',
-                             sort_direction: str = 'desc', type: str = None, passphrase: str = None,
-                             additional: list = None) -> dict[str, object] | str:
+    def list_item_in_folders(self, offset: int = 0, limit: int = 1000, folder_id: Optional[int] = None,
+                             sort_by: str = 'filename', sort_direction: str = 'desc', type: str = None,
+                             passphrase: str = None, additional: Optional[list[str]] = None
+                             ) -> dict[str, object] | str:
         """
-        List all items in all folders in Personal Space.
+        List items in a Personal Space folder.
 
         Parameters
         ----------
         offset : int
-            Specify how many shared folders are skipped before beginning to return listed shared folders.
+            Specify how many items are skipped before beginning to return listed items.
         limit : int
-            Number of shared folders requested. Set to `0` to list all shared folders.
-        folder_id : int
-            ID of folder.
+            Number of items requested. Default is 1000.
+        folder_id : int, required
+            ID of the folder returned by ``list_folders``.
         sort_by : str, optional
             Possible values: 'filename', 'filesize', 'takentime', 'item_type'.
         sort_direction : str, optional
@@ -673,18 +674,95 @@ class Photos(base_api.BaseApi):
         dict[str, object] or str
             The list of items or an error message.
         """
-        api_name = 'SYNO.Foto.Browse.Item'
+        return self._list_items_in_folder(
+            'SYNO.Foto.Browse.Item', offset, limit, folder_id, sort_by, sort_direction, type, passphrase, additional)
+
+    def list_item_in_team_folders(self, offset: int = 0, limit: int = 1000, folder_id: Optional[int] = None,
+                                  sort_by: str = 'filename', sort_direction: str = 'desc', type: str = None,
+                                  passphrase: str = None, additional: Optional[list[str]] = None
+                                  ) -> dict[str, object] | str:
+        """
+        List items in a Team Space folder.
+
+        Parameters
+        ----------
+        offset : int
+            Specify how many items are skipped before beginning to return listed items.
+        limit : int
+            Number of items requested. Default is 1000.
+        folder_id : int, required
+            ID of the folder returned by ``list_teams_folders``.
+        sort_by : str, optional
+            Possible values: 'filename', 'filesize', 'takentime', 'item_type'.
+        sort_direction : str, optional
+            Possible values: 'asc' or 'desc'. Defaults to: 'desc'.
+        type : str, optional
+            Possible values: 'photo', 'video', 'live'.
+        passphrase : str, optional
+            Passphrase for a shared album.
+        additional : list, optional
+            Additional fields to include.
+            Possible values:
+                `["thumbnail","resolution", "orientation", "video_convert", "video_meta", "provider_user_id", "exif", "tag", "description", "gps", "geocoding_id", "address", "person"]`.
+
+        Returns
+        -------
+        dict[str, object] or str
+            The list of team items or an error message.
+        """
+        return self._list_items_in_folder(
+            'SYNO.FotoTeam.Browse.Item', offset, limit, folder_id, sort_by, sort_direction, type, passphrase, additional)
+
+    def _list_items_in_folder(self, api_name: str, offset: int, limit: int, folder_id: Optional[int], sort_by: str,
+                              sort_direction: str, item_type: Optional[str], passphrase: Optional[str],
+                              additional: Optional[list[str]]) -> Any:
+        """
+        Internal method to list items in a Photos folder.
+
+        Parameters
+        ----------
+        api_name : str
+            API name to use.
+        offset : int
+            Specify how many items are skipped before beginning to return listed items.
+        limit : int
+            Number of items requested.
+        folder_id : int
+            ID of the folder.
+        sort_by : str
+            Sort field.
+        sort_direction : str
+            Sort direction.
+        item_type : str, optional
+            Item type filter.
+        passphrase : str, optional
+            Passphrase for a shared album.
+        additional : list, optional
+            Additional fields to include.
+
+        Returns
+        -------
+        Any
+            The API response.
+        """
+        if folder_id is None:
+            raise ValueError(
+                'folder_id is required; call list_folders() or list_teams_folders() first to find it.')
+        if limit <= 0:
+            raise ValueError(
+                'limit must be greater than 0 for Synology Photos item listing.')
+
         info = self.photos_list[api_name]
         api_path = info['path']
         req_param = {'version': info['maxVersion'], 'method': 'list', 'offset': offset, 'limit': limit,
                      'folder_id': folder_id, 'sort_by': sort_by, 'sort_direction': sort_direction}
 
-        if type:
-            req_param['type'] = type
+        if item_type:
+            req_param['type'] = item_type
         if passphrase:
             req_param['passphrase'] = passphrase
         if additional:
-            req_param['additional'] = additional
+            req_param['additional'] = json.dumps(additional)
 
         return self.request_data(api_name, api_path, req_param)
 

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -1,0 +1,95 @@
+"""Unit tests for Synology Photos request contracts."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from synology_api.photos import Photos
+
+
+def _make_instance():
+    """Create a Photos instance with mocked auth/session."""
+    with patch('synology_api.photos.base_api.BaseApi.__init__', return_value=None):
+        instance = Photos.__new__(Photos)
+
+    instance.photos_list = {
+        'SYNO.Foto.Browse.Item': {'path': 'entry.cgi', 'maxVersion': 1},
+        'SYNO.FotoTeam.Browse.Item': {'path': 'entry.cgi', 'maxVersion': 1},
+    }
+    instance.request_data = MagicMock(
+        return_value={'success': True, 'data': {'list': []}})
+    return instance
+
+
+class TestPhotos(unittest.TestCase):
+    """Tests for Photos methods."""
+
+    def setUp(self):
+        self.instance = _make_instance()
+
+    def test_list_item_in_folders_requires_folder_id(self):
+        with self.assertRaisesRegex(ValueError, 'folder_id is required'):
+            self.instance.list_item_in_folders(limit=10)
+
+    def test_list_item_in_folders_requires_positive_limit(self):
+        with self.assertRaisesRegex(ValueError, 'limit must be greater than 0'):
+            self.instance.list_item_in_folders(folder_id=123, limit=0)
+
+    def test_list_item_in_folders_sends_personal_space_request(self):
+        response = self.instance.list_item_in_folders(
+            folder_id=123,
+            offset=5,
+            limit=25,
+            type='photo',
+            additional=['thumbnail'],
+        )
+
+        self.assertEqual(response, {'success': True, 'data': {'list': []}})
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.Foto.Browse.Item',
+            'entry.cgi',
+            {
+                'version': 1,
+                'method': 'list',
+                'offset': 5,
+                'limit': 25,
+                'folder_id': 123,
+                'sort_by': 'filename',
+                'sort_direction': 'desc',
+                'type': 'photo',
+                'additional': json.dumps(['thumbnail']),
+            },
+        )
+
+    def test_list_item_in_team_folders_sends_team_space_request(self):
+        self.instance.list_item_in_team_folders(
+            folder_id=456,
+            offset=10,
+            limit=50,
+            sort_by='takentime',
+            sort_direction='asc',
+            type='video',
+            passphrase='secret',
+            additional=['thumbnail', 'resolution'],
+        )
+
+        self.instance.request_data.assert_called_once_with(
+            'SYNO.FotoTeam.Browse.Item',
+            'entry.cgi',
+            {
+                'version': 1,
+                'method': 'list',
+                'offset': 10,
+                'limit': 50,
+                'folder_id': 456,
+                'sort_by': 'takentime',
+                'sort_direction': 'asc',
+                'type': 'video',
+                'passphrase': 'secret',
+                'additional': json.dumps(['thumbnail', 'resolution']),
+            },
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## :card_file_box: Summary

Fix Synology Photos item listing so callers must provide a folder id before listing photo/video/live items.

---

## :rocket: Motivation & Problem Statement

Fixes #233. `list_item_in_folders()` looked like a global Photos listing helper because it defaulted `folder_id=0` and `limit=0`, but Synology Photos item listing requires a real folder id from the folder listing API.

---

## :wrench: Implementation Details

- Updated `synology_api/photos.py` so `list_item_in_folders()` defaults `limit` to `1000`, requires `folder_id`, validates `limit > 0`, and serializes `additional` as JSON.
- Added `list_item_in_team_folders()` for Team Space item listing using `SYNO.FotoTeam.Browse.Item`.
- Added `tests/test_photos.py` request-contract coverage for Personal Space, Team Space, missing `folder_id`, and invalid `limit`.
- Updated the generated Photos API docs page for the clarified item-listing behavior.

---

## :checkered_flag: Checklist

- [x] I have read and followed the [Contributing guidelines](CONTRIBUTING.md).
- [x] All new or modified code is covered by unit tests (`tests/`).
- [x] Tests pass locally (`pytest`).
- [x] I added or updated documentation where necessary.
- [ ] I updated the changelog or added a new section if this is a major change.
- [x] I followed the style guidelines (`black`, `flake8`, etc.).
- [ ] I ran `pre-commit` and addressed any linting issues.

---

## :memo: Related Issue

Fixes #233

---

## :hammer: Additional Notes

- Live read-only smoke against `LIVE ACCOUNT`: login succeeded, `get_userinfo` succeeded, `list_folders(limit=10)` returned one personal-space folder, and `list_item_in_folders(folder_id=<folder id>, limit=10, type='photo')` returned success.
- Team Space listing returned `PhotosError 801` for `LIVE ACCOUNT`, so the live smoke was limited to Personal Space.
- Full non-integration suite with NAS access: `484 passed, 1 failed`; the one failure is unrelated to Photos because `tests/test_add_s3_sync_task.py::test_create_s3_task_list` assumes an existing CloudSync connection, while the NAS returned an empty connection list.

---

## :sunglasses: Test & Build Status

```text
.venv/bin/python -m pytest tests/test_photos.py -q
4 passed

PYTHONPATH=tests .venv/bin/python -m pytest tests -q --ignore=tests/integration
484 passed, 1 failed

PYTHONPATH=tests .venv/bin/python -m pytest tests -q --ignore=tests/integration --ignore=tests/test_add_s3_sync_task.py
483 passed

git diff --check
passed
```

---

## :eyes: Screenshots / Media

Not applicable.
