### PR TITLE
Add QuickConnect transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ ds_info = ds.get_info()
 
 ```
 
+For NAS devices reachable through QuickConnect, pass the NAS QuickConnect ID
+instead of an IP address and port. QuickConnect uses HTTPS automatically.
+
+```python
+fs = FileStation(
+    quickconnect_id='QuickConnect ID',
+    username='Username',
+    password='Password',
+    cert_verify=False,
+    dsm_version=7,
+    debug=True,
+    otp_code=None
+)
+```
+
 ## Available Functions
 
 At the moment there are around +300 APIs implemented with countless methods for each, the majority is not documented, but some are.
@@ -121,4 +136,3 @@ Check [Contribute - Contribution 101](https://n4s4.github.io/synology-api/docs/c
 ## Contributors
 
 - List of contributors here: [Contributors](https://github.com/N4S4/synology-api/graphs/contributors)
-

--- a/documentation/docs/apis/classes/base_api.md
+++ b/documentation/docs/apis/classes/base_api.md
@@ -18,6 +18,10 @@ The **session** is created on instantiation.
 If accessing the NAS through a **remote connection**, it is advised to use _HTTPS_ to connect to it. Please make sure the certificate is valid.
 :::
 
+:::tip
+For QuickConnect access, pass `quickconnect_id` with `username` and `password`. The client resolves the relay URL and uses HTTPS automatically, so `ip_address` and `port` are not required.
+:::
+
 #### Parameters
 <div class="padding-left--md">
 
@@ -45,8 +49,11 @@ _**dsm_version**_ `int`
 _**debug**_ `bool`
     Whether to print debug messages or not. Defaults to `True`.
 
-_**otp_code**_ `str`  
+_**otp_code**_ `str`
     The OTP code to use for authentication. Defaults to `None`.
+
+_**quickconnect_id**_ `str`
+    QuickConnect ID for relay-based access. Defaults to `None`.
 </div>
 
 ## Methods

--- a/documentation/docs/getting-started/usage.md
+++ b/documentation/docs/getting-started/usage.md
@@ -43,6 +43,25 @@ sidebar_position: 3
     ds_info = ds.get_info()
     ```
 
+### QuickConnect workflow
+QuickConnect connections use HTTPS automatically and do not require a NAS IP address or port.
+
+```python
+from synology_api.filestation import FileStation
+
+fs = FileStation(
+    quickconnect_id='QuickConnect ID',
+    username='Username',
+    password='Password',
+    cert_verify=False,
+    dsm_version=7,
+    debug=True,
+    otp_code=None
+)
+
+fs_info = fs.get_info()
+```
+
 ### Complete Example
 
 :::note

--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -33,6 +33,7 @@ from noise.connection import NoiseConnection, Keypair
 import time
 
 USE_EXCEPTIONS: bool = True
+QUICKCONNECT_GLOBAL_URL = "https://global.quickconnect.to/Serv.php"
 
 
 class Authentication:
@@ -63,20 +64,23 @@ class Authentication:
         Device ID for device binding.
     device_name : str, optional
         Device name for device binding.
+    quickconnect_id : str, optional
+        QuickConnect ID for relay-based access.
     """
 
     def __init__(self,
-                 ip_address: str,
-                 port: str,
-                 username: str,
-                 password: str,
+                 ip_address: Optional[str] = None,
+                 port: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
                  secure: bool = False,
                  cert_verify: bool = False,
                  dsm_version: int = 7,
                  debug: bool = True,
                  otp_code: Optional[str] = None,
                  device_id: Optional[str] = None,
-                 device_name: Optional[str] = None
+                 device_name: Optional[str] = None,
+                 quickconnect_id: Optional[str] = None
                  ) -> None:
         """
         Initialize the Authentication object for Synology DSM.
@@ -105,17 +109,30 @@ class Authentication:
             Device ID for device binding (default is None).
         device_name : str, optional
             Device name for device binding (default is None).
+        quickconnect_id : str, optional
+            QuickConnect ID for relay-based access. When provided, HTTPS is
+            always used and `ip_address`/`port` are not required.
 
         Returns
         -------
         None
             Just setter, no return values.
         """
-        self._ip_address: str = ip_address
-        self._port: str = port
+        if quickconnect_id:
+            missing_credentials = not all([username, password])
+        else:
+            missing_credentials = not all(
+                [ip_address, port, username, password])
+        if missing_credentials:
+            raise ValueError(
+                "Missing required credentials for initial authentication.")
+
+        self._quickconnect_id: Optional[str] = quickconnect_id
+        self._ip_address: Optional[str] = ip_address
+        self._port: Optional[str] = port
         self._username: str = username
         self._password: str = password
-        self._secure: bool = secure
+        self._secure: bool = True if self._quickconnect_id else secure
         self._sid: Optional[str] = None
         self._syno_token: Optional[str] = None
         self._session_expire: bool = True
@@ -129,13 +146,202 @@ class Authentication:
         if self._verify is False:
             disable_warnings(InsecureRequestWarning)
 
-        schema = 'https' if secure else 'http'
-
-        self._base_url = '%s://%s:%s/webapi/' % (
-            schema, self._ip_address, self._port)
+        self._requests_session: Optional[requests.Session] = None
+        self._quickconnect_headers: dict[str, str] = {}
+        if self._quickconnect_id:
+            self._base_url = self._build_quickconnect_base_url()
+        else:
+            schema = 'https' if secure else 'http'
+            self._base_url = '%s://%s:%s/webapi/' % (
+                schema, self._ip_address, self._port)
 
         self.full_api_list = {}
         self.app_api_list = {}
+
+    def _quickconnect_payload(self, command: str) -> list[dict[str, object]]:
+        """
+        Build a QuickConnect relay discovery request.
+
+        Parameters
+        ----------
+        command : str
+            QuickConnect command to send to Synology's relay service.
+
+        Returns
+        -------
+        list[dict[str, object]]
+            Request payload accepted by the QuickConnect service.
+        """
+        return [{
+            "version": 1,
+            "command": command,
+            "id": "mainapp_https",
+            "serverID": self._quickconnect_id,
+            "stop_when_error": False,
+            "stop_when_success": command == "request_tunnel",
+            "is_gofile": False,
+            "path": ""
+        }]
+
+    @staticmethod
+    def _quickconnect_response_data(response_json: list[dict[str, object]],
+                                    command: str) -> dict[str, object]:
+        """
+        Validate and unwrap a QuickConnect response.
+
+        Parameters
+        ----------
+        response_json : list[dict[str, object]]
+            JSON returned by Synology's QuickConnect service.
+        command : str
+            Command used for the request, included in error messages.
+
+        Returns
+        -------
+        dict[str, object]
+            First successful response item.
+        """
+        if not response_json or response_json[0].get("errno") != 0:
+            error = response_json[0] if response_json else {}
+            errno = error.get("errno", "unknown")
+            errinfo = error.get("errinfo", "")
+            raise SynoConnectionError(
+                error_message=f"QuickConnect {command} failed: {errno} {errinfo}".strip())
+        return response_json[0]
+
+    def _build_quickconnect_base_url(self) -> str:
+        """
+        Resolve a QuickConnect ID to a relay URL and prime relay cookies.
+
+        Returns
+        -------
+        str
+            Base DSM webapi URL through the QuickConnect relay.
+        """
+        try:
+            server_info_response = requests.post(
+                QUICKCONNECT_GLOBAL_URL,
+                json=self._quickconnect_payload("get_server_info"),
+                verify=self._verify
+            )
+            server_info_response.raise_for_status()
+            server_info = self._quickconnect_response_data(
+                server_info_response.json(), "get_server_info")
+            control_host = server_info.get("env", {}).get("control_host")
+            if not control_host:
+                raise SynoConnectionError(
+                    error_message="QuickConnect get_server_info did not return a control_host")
+
+            tunnel_response = requests.post(
+                f"https://{control_host}/Serv.php",
+                json=self._quickconnect_payload("request_tunnel"),
+                verify=self._verify
+            )
+            tunnel_response.raise_for_status()
+            tunnel_info = self._quickconnect_response_data(
+                tunnel_response.json(), "request_tunnel")
+        except requests.exceptions.ConnectionError as e:
+            raise SynoConnectionError(error_message=e.args[0])
+        except requests.exceptions.HTTPError as e:
+            raise HTTPError(error_message=str(e.args))
+        except requests.exceptions.JSONDecodeError as e:
+            raise JSONDecodeError(error_message=str(e.args))
+
+        relay_region = tunnel_info.get("env", {}).get("relay_region")
+        pingpong_path = tunnel_info.get("server", {}).get("pingpong_path")
+        if not relay_region or not pingpong_path:
+            raise SynoConnectionError(
+                error_message="QuickConnect request_tunnel did not return relay_region and pingpong_path")
+
+        quickconnect_origin = f"https://{self._quickconnect_id}.{relay_region}.quickconnect.to"
+        self._ip_address = f"{self._quickconnect_id}.{relay_region}.quickconnect.to"
+        self._port = "443"
+        self._quickconnect_headers = {
+            "Origin": quickconnect_origin,
+            "Referer": quickconnect_origin
+        }
+        self._requests_session = requests.Session()
+        try:
+            ping_response = self._get(
+                f"{quickconnect_origin}{pingpong_path}", verify=self._verify)
+            ping_response.raise_for_status()
+        except requests.exceptions.ConnectionError as e:
+            raise SynoConnectionError(error_message=e.args[0])
+        except requests.exceptions.HTTPError as e:
+            raise HTTPError(error_message=str(e.args))
+
+        return f"{quickconnect_origin}/webapi/"
+
+    def _merge_headers(self, headers: Optional[dict[str, str]] = None) -> dict[str, str] | None:
+        """
+        Merge QuickConnect relay headers into request headers.
+
+        Parameters
+        ----------
+        headers : dict[str, str], optional
+            Request-specific headers.
+
+        Returns
+        -------
+        dict[str, str] or None
+            Merged headers, or None when no headers are needed.
+        """
+        if not self._quickconnect_headers:
+            return headers
+        merged_headers = self._quickconnect_headers.copy()
+        if headers:
+            merged_headers.update(headers)
+        return merged_headers
+
+    def _get(self, url: str, params: Optional[dict[str, object]] = None, **kwargs) -> requests.Response:
+        """
+        Send a GET request through the active transport.
+
+        Parameters
+        ----------
+        url : str
+            Request URL.
+        params : dict[str, object], optional
+            Query parameters.
+        **kwargs : object
+            Additional request keyword arguments.
+
+        Returns
+        -------
+        requests.Response
+            Response from requests.
+        """
+        kwargs["headers"] = self._merge_headers(kwargs.get("headers"))
+        if kwargs["headers"] is None:
+            kwargs.pop("headers")
+        if self._requests_session:
+            return self._requests_session.get(url, params=params, **kwargs)
+        return requests.get(url, params=params, **kwargs)
+
+    def _post(self, url: str, data: Any = None, **kwargs) -> requests.Response:
+        """
+        Send a POST request through the active transport.
+
+        Parameters
+        ----------
+        url : str
+            Request URL.
+        data : Any, optional
+            Request body.
+        **kwargs : object
+            Additional request keyword arguments.
+
+        Returns
+        -------
+        requests.Response
+            Response from requests.
+        """
+        kwargs["headers"] = self._merge_headers(kwargs.get("headers"))
+        if kwargs["headers"] is None:
+            kwargs.pop("headers")
+        if self._requests_session:
+            return self._requests_session.post(url, data=data, **kwargs)
+        return requests.post(url, data=data, **kwargs)
 
     def get_ik_message(self) -> str:
         """
@@ -153,7 +359,7 @@ class Authentication:
             "method": "get",
             "version": "1"
         }
-        response = requests.post(url, data=data, verify=self._verify)
+        response = self._post(url, data=data, verify=self._verify)
 
         # Try to get cookie "_SSID"
         if response.status_code != 200:
@@ -209,7 +415,7 @@ class Authentication:
         LoginError
             If login fails due to an API error.
         """
-        login_api = 'auth.cgi'
+        login_api = 'entry.cgi' if self._quickconnect_id else 'auth.cgi'
         params = {'api': "SYNO.API.Auth", 'version': self._version,
                   'method': 'login', 'enable_syno_token': 'yes', 'client': 'browser'}
 
@@ -249,7 +455,7 @@ class Authentication:
             session_request_json: dict[str, object] = {}
             if USE_EXCEPTIONS:
                 try:
-                    session_request = requests.post(
+                    session_request = self._post(
                         self._base_url + login_api, data=params, verify=self._verify)
                     session_request.raise_for_status()
                     session_request_json = session_request.json()
@@ -261,7 +467,7 @@ class Authentication:
                     raise JSONDecodeError(error_message=str(e.args))
             else:
                 # Will raise its own errors:
-                session_request = requests.post(
+                session_request = self._post(
                     self._base_url + login_api, data=params, verify=self._verify)
                 session_request_json = session_request.json()
 
@@ -297,13 +503,13 @@ class Authentication:
         LogoutError
             If logout fails due to an API error.
         """
-        logout_api = 'auth.cgi?api=SYNO.API.Auth'
+        logout_api = 'entry.cgi?api=SYNO.API.Auth' if self._quickconnect_id else 'auth.cgi?api=SYNO.API.Auth'
         param = {'version': self._version,
                  'method': 'logout', 'session': 'webui'}
 
         if USE_EXCEPTIONS:
             try:
-                response = requests.get(
+                response = self._get(
                     self._base_url + logout_api, param, verify=self._verify)
                 response.raise_for_status()
                 response_json = response.json()
@@ -315,7 +521,7 @@ class Authentication:
             except requests.exceptions.JSONDecodeError as e:
                 raise JSONDecodeError(error_message=str(e.args))
         else:
-            response = requests.get(
+            response = self._get(
                 self._base_url + logout_api, param, verify=self._verify)
             error_code = self._get_error_code(response.json())
         self._session_expire = True
@@ -355,7 +561,7 @@ class Authentication:
         if USE_EXCEPTIONS:
             # Check request for error, and raise our own error.:
             try:
-                response = requests.get(
+                response = self._get(
                     self._base_url + query_path, list_query, verify=self._verify)
                 response.raise_for_status()
                 response_json = response.json()
@@ -367,7 +573,7 @@ class Authentication:
                 raise JSONDecodeError(error_message=str(e.args))
         else:
             # Will raise its own errors:
-            response_json = requests.get(
+            response_json = self._get(
                 self._base_url + query_path, list_query, verify=self._verify).json()
 
         if app is not None:
@@ -611,11 +817,11 @@ class Authentication:
         # We get it from the self._syno_token variable and by param 'enable_syno_token':'yes' in the login request
 
         if method == 'get':
-            response = requests.get(url, req_param, verify=self._verify, headers={
-                                    "X-SYNO-TOKEN": self._syno_token})
+            response = self._get(url, req_param, verify=self._verify, headers={
+                                 "X-SYNO-TOKEN": self._syno_token})
         elif method == 'post':
-            response = requests.post(url, req_param, verify=self._verify, headers={
-                                     "X-SYNO-TOKEN": self._syno_token})
+            response = self._post(url, req_param, verify=self._verify, headers={
+                                  "X-SYNO-TOKEN": self._syno_token})
 
         if response_json is True:
             return response.json()
@@ -680,17 +886,17 @@ class Authentication:
             # Catch and raise our own errors:
             try:
                 if method == 'get':
-                    response = requests.get(url, req_param, verify=self._verify, headers={
-                                            "X-SYNO-TOKEN": self._syno_token})
+                    response = self._get(url, req_param, verify=self._verify, headers={
+                                         "X-SYNO-TOKEN": self._syno_token})
                 elif method == 'post':
                     if data is None:
-                        response = requests.post(url, req_param, verify=self._verify, headers={
-                                                 "X-SYNO-TOKEN": self._syno_token})
+                        response = self._post(url, req_param, verify=self._verify, headers={
+                                              "X-SYNO-TOKEN": self._syno_token})
                     else:
                         url = ('%s%s' % (self._base_url, api_path)) + \
                             '/' + api_name
-                        response = requests.post(url, data=data, params=req_param, verify=self._verify, headers={
-                                                 "Content-Type": data.content_type, "X-SYNO-TOKEN": self._syno_token})
+                        response = self._post(url, data=data, params=req_param, verify=self._verify, headers={
+                                              "Content-Type": data.content_type, "X-SYNO-TOKEN": self._syno_token})
                 response.raise_for_status()
             except requests.exceptions.ConnectionError as e:
                 raise SynoConnectionError(error_message=e.args[0])
@@ -699,11 +905,11 @@ class Authentication:
         else:
             # Will raise its own error:
             if method == 'get':
-                response = requests.get(url, req_param, verify=self._verify, headers={
-                                        "X-SYNO-TOKEN": self._syno_token})
+                response = self._get(url, req_param, verify=self._verify, headers={
+                                     "X-SYNO-TOKEN": self._syno_token})
             elif method == 'post':
-                response = requests.post(url, req_param, verify=self._verify, headers={
-                                         "X-SYNO-TOKEN": self._syno_token})
+                response = self._post(url, req_param, verify=self._verify, headers={
+                                      "X-SYNO-TOKEN": self._syno_token})
             response.raise_for_status()
 
         # Check for error response from dsm:

--- a/synology_api/base_api.py
+++ b/synology_api/base_api.py
@@ -41,16 +41,18 @@ class BaseApi(object):
         Device name for device binding. Defaults to `None`.
     application : str, optional
         The application context for API list retrieval. Defaults to `'Core'`.
+    quickconnect_id : str, optional
+        QuickConnect ID for relay-based access. Defaults to `None`.
     """
 
     # Class-level attribute to store the shared session
     shared_session: Optional[syn.Authentication] = None
 
     def __init__(self,
-                 ip_address: str,
-                 port: str,
-                 username: str,
-                 password: str,
+                 ip_address: Optional[str] = None,
+                 port: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
                  secure: bool = False,
                  cert_verify: bool = False,
                  dsm_version: int = 7,
@@ -59,6 +61,7 @@ class BaseApi(object):
                  device_id: Optional[str] = None,
                  device_name: Optional[str] = None,
                  application: str = 'Core',
+                 quickconnect_id: Optional[str] = None,
                  ) -> None:
         """
         Initialize the BaseApi object and create or reuse a session.
@@ -89,6 +92,9 @@ class BaseApi(object):
             Device name for device binding. Defaults to `None`.
         application : str, optional
             The application context for API list retrieval. Defaults to `'Core'`.
+        quickconnect_id : str, optional
+            QuickConnect ID for relay-based access. When provided, `ip_address`
+            and `port` are not required.
 
         Returns
         -------
@@ -101,13 +107,18 @@ class BaseApi(object):
         if BaseApi.shared_session:
             self.session = BaseApi.shared_session
         else:
-            if not all([ip_address, port, username, password]):
+            if quickconnect_id:
+                missing_credentials = not all([username, password])
+            else:
+                missing_credentials = not all(
+                    [ip_address, port, username, password])
+            if missing_credentials:
                 raise ValueError(
                     "Missing required credentials for initial authentication.")
 
             self.session = syn.Authentication(
                 ip_address, port, username, password, secure, cert_verify, dsm_version, debug, otp_code,
-                device_id, device_name
+                device_id, device_name, quickconnect_id
             )
             self.session.login()
             self.session.get_api_list(self.application)

--- a/synology_api/core_certificate.py
+++ b/synology_api/core_certificate.py
@@ -37,20 +37,23 @@ class Certificate(base_api.BaseApi):
         Enable debug output (default is True).
     otp_code : Optional[str], optional
         One-time password for 2FA (default is None).
+    quickconnect_id : str, optional
+        QuickConnect ID for relay-based access. Defaults to None.
     """
 
     _API_NAME = 'SYNO.Core.Certificate.CRT'
 
     def __init__(self,
-                 ip_address: str,
-                 port: str,
-                 username: str,
-                 password: str,
+                 ip_address: Optional[str] = None,
+                 port: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
                  secure: bool = False,
                  cert_verify: bool = False,
                  dsm_version: int = 7,
                  debug: bool = True,
-                 otp_code: Optional[str] = None
+                 otp_code: Optional[str] = None,
+                 quickconnect_id: Optional[str] = None
                  ) -> None:
         """
         Initialize the Certificate API wrapper.
@@ -75,9 +78,12 @@ class Certificate(base_api.BaseApi):
             Enable debug output (default is True).
         otp_code : Optional[str], optional
             One-time password for 2FA (default is None).
+        quickconnect_id : str, optional
+            QuickConnect ID for relay-based access. When provided, `ip_address`
+            and `port` are not required.
         """
         super(Certificate, self).__init__(ip_address, port, username, password, secure, cert_verify, dsm_version, debug,
-                                          otp_code)
+                                          otp_code, application='Core', quickconnect_id=quickconnect_id)
         self._debug: bool = debug
 
     def _base_certificate_methods(self,

--- a/synology_api/downloadstation.py
+++ b/synology_api/downloadstation.py
@@ -79,13 +79,15 @@ class DownloadStation(base_api.BaseApi):
         Enable interactive output (default is True).
     download_st_version : int, optional
         Download Station API version (default is None).
+    quickconnect_id : str, optional
+        QuickConnect ID for relay-based access. Defaults to None.
     """
 
     def __init__(self,
-                 ip_address: str,
-                 port: str,
-                 username: str,
-                 password: str,
+                 ip_address: Optional[str] = None,
+                 port: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
                  secure: bool = False,
                  cert_verify: bool = False,
                  dsm_version: int = 7,
@@ -94,7 +96,8 @@ class DownloadStation(base_api.BaseApi):
                  device_id: Optional[str] = None,
                  device_name: Optional[str] = None,
                  interactive_output: bool = True,
-                 download_st_version: int = None
+                 download_st_version: int = None,
+                 quickconnect_id: Optional[str] = None
                  ) -> None:
         """
         Initialize the DownloadStation API wrapper.
@@ -127,10 +130,14 @@ class DownloadStation(base_api.BaseApi):
             Enable interactive output (default is True).
         download_st_version : int, optional
             Download Station API version (default is None).
+        quickconnect_id : str, optional
+            QuickConnect ID for relay-based access. When provided, `ip_address`
+            and `port` are not required.
         """
 
         super(DownloadStation, self).__init__(ip_address, port, username, password, secure, cert_verify,
-                                              dsm_version, debug, otp_code, device_id, device_name, 'DownloadStation')
+                                              dsm_version, debug, otp_code, device_id, device_name, 'DownloadStation',
+                                              quickconnect_id=quickconnect_id)
 
         self._bt_search_id: str = ''
         self._bt_search_id_list: list[str] = []

--- a/synology_api/filestation.py
+++ b/synology_api/filestation.py
@@ -112,13 +112,15 @@ class FileStation(base_api.BaseApi):
         Name of the device. Default is None.
     interactive_output : bool, optional
         If True, enables interactive output. Default is False.
+    quickconnect_id : str, optional
+        QuickConnect ID for relay-based access. Defaults to None.
     """
 
     def __init__(self,
-                 ip_address: str,
-                 port: str,
-                 username: str,
-                 password: str,
+                 ip_address: Optional[str] = None,
+                 port: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
                  secure: bool = False,
                  cert_verify: bool = False,
                  dsm_version: int = 7,
@@ -126,7 +128,8 @@ class FileStation(base_api.BaseApi):
                  otp_code: Optional[str] = None,
                  device_id: Optional[str] = None,
                  device_name: Optional[str] = None,
-                 interactive_output: bool = True
+                 interactive_output: bool = True,
+                 quickconnect_id: Optional[str] = None
                  ) -> None:
         """
         Initialize FileStation API client.
@@ -157,9 +160,13 @@ class FileStation(base_api.BaseApi):
             Device name for authentication.
         interactive_output : bool, optional
             If True, outputs are formatted for interactive use. Default is True.
+        quickconnect_id : str, optional
+            QuickConnect ID for relay-based access. When provided, `ip_address`
+            and `port` are not required.
         """
         super(FileStation, self).__init__(ip_address, port, username, password, secure, cert_verify,
-                                          dsm_version, debug, otp_code, device_id, device_name, 'FileStation')
+                                          dsm_version, debug, otp_code, device_id, device_name, 'FileStation',
+                                          quickconnect_id=quickconnect_id)
 
         self._dir_taskid: str = ''
         self._dir_taskid_list: list[str] = []

--- a/synology_api/photos.py
+++ b/synology_api/photos.py
@@ -41,20 +41,23 @@ class Photos(base_api.BaseApi):
         Device ID for the session.
     device_name : str, optional
         Device name for the session.
+    quickconnect_id : str, optional
+        QuickConnect ID for relay-based access. Defaults to None.
     """
 
     def __init__(self,
-                 ip_address: str,
-                 port: str,
-                 username: str,
-                 password: str,
+                 ip_address: Optional[str] = None,
+                 port: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
                  secure: bool = False,
                  cert_verify: bool = False,
                  dsm_version: int = 7,
                  debug: bool = True,
                  otp_code: Optional[str] = None,
                  device_id: Optional[str] = None,
-                 device_name: Optional[str] = None
+                 device_name: Optional[str] = None,
+                 quickconnect_id: Optional[str] = None
                  ) -> None:
         """
         Initialize the Photos API interface.
@@ -83,10 +86,14 @@ class Photos(base_api.BaseApi):
             Device ID for the session.
         device_name : str, optional
             Device name for the session.
+        quickconnect_id : str, optional
+            QuickConnect ID for relay-based access. When provided, `ip_address`
+            and `port` are not required.
         """
 
         super(Photos, self).__init__(ip_address, port, username, password, secure, cert_verify,
-                                     dsm_version, debug, otp_code, device_id, device_name, 'FotoStation')
+                                     dsm_version, debug, otp_code, device_id, device_name, 'FotoStation',
+                                     quickconnect_id=quickconnect_id)
 
         self.session.get_api_list('Foto')
 

--- a/synology_api/virtualization.py
+++ b/synology_api/virtualization.py
@@ -36,18 +36,21 @@ class Virtualization(base_api.BaseApi):
         Enable debug mode. Default is True.
     otp_code : str, optional
         One-time password for 2FA, if required.
+    quickconnect_id : str, optional
+        QuickConnect ID for relay-based access. Defaults to None.
     """
 
     def __init__(self,
-                 ip_address: str,
-                 port: str,
-                 username: str,
-                 password: str,
+                 ip_address: Optional[str] = None,
+                 port: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
                  secure: bool = False,
                  cert_verify: bool = False,
                  dsm_version: int = 7,
                  debug: bool = True,
-                 otp_code: Optional[str] = None
+                 otp_code: Optional[str] = None,
+                 quickconnect_id: Optional[str] = None
                  ) -> None:
         """
         Initialize the Virtualization API wrapper.
@@ -72,10 +75,14 @@ class Virtualization(base_api.BaseApi):
             Enable debug mode. Default is True.
         otp_code : str, optional
             One-time password for 2FA, if required.
+        quickconnect_id : str, optional
+            QuickConnect ID for relay-based access. When provided, `ip_address`
+            and `port` are not required.
         """
 
         super(Virtualization, self).__init__(ip_address, port, username, password, secure, cert_verify,
-                                             dsm_version, debug, otp_code)
+                                             dsm_version, debug, otp_code, application='Core',
+                                             quickconnect_id=quickconnect_id)
 
         self._taskid_list: Any = []
         self._network_group_list: Any = []

--- a/tests/test_quickconnect.py
+++ b/tests/test_quickconnect.py
@@ -1,0 +1,253 @@
+"""Unit tests for QuickConnect transport support."""
+
+import unittest
+from unittest.mock import ANY, MagicMock, patch
+
+from synology_api.auth import Authentication
+from synology_api.base_api import BaseApi
+from synology_api.filestation import FileStation
+
+
+class FakeResponse:
+    """Minimal requests response fake for transport tests."""
+
+    def __init__(self, json_data=None):
+        self._json_data = json_data
+        self.cookies = {}
+        self.status_code = 200
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        return None
+
+
+def _quickconnect_post_responses():
+    return [
+        FakeResponse([{
+            "errno": 0,
+            "env": {"control_host": "control.quickconnect.to"},
+            "server": {"ds_state": "CONNECTED"}
+        }]),
+        FakeResponse([{
+            "errno": 0,
+            "env": {"relay_region": "us"},
+            "server": {"pingpong_path": "/webman/pingpong.cgi"}
+        }])
+    ]
+
+
+class TestQuickConnect(unittest.TestCase):
+    """Tests for QuickConnect request contracts."""
+
+    def tearDown(self):
+        BaseApi.shared_session = None
+
+    @patch.object(Authentication, "get_ik_message", return_value="ik-message")
+    @patch("synology_api.auth.requests.Session")
+    @patch("synology_api.auth.requests.post")
+    def test_authentication_resolves_quickconnect_and_logs_in(self, post, session_class, _get_ik):
+        session = MagicMock()
+        session.get.return_value = FakeResponse({"success": True})
+        session.post.return_value = FakeResponse({
+            "success": True,
+            "data": {"sid": "sid-123", "synotoken": "token-123"}
+        })
+        session_class.return_value = session
+        post.side_effect = _quickconnect_post_responses()
+
+        auth = Authentication(
+            username="user",
+            password="pass",
+            quickconnect_id="my-nas",
+            cert_verify=False,
+            debug=False
+        )
+        auth.login()
+
+        self.assertEqual(
+            auth.base_url,
+            "https://my-nas.us.quickconnect.to/webapi/"
+        )
+        self.assertEqual(auth.sid, "sid-123")
+        self.assertEqual(auth.syno_token, "token-123")
+        self.assertTrue(auth._secure)
+
+        post.assert_any_call(
+            "https://global.quickconnect.to/Serv.php",
+            json=[{
+                "version": 1,
+                "command": "get_server_info",
+                "id": "mainapp_https",
+                "serverID": "my-nas",
+                "stop_when_error": False,
+                "stop_when_success": False,
+                "is_gofile": False,
+                "path": ""
+            }],
+            verify=False
+        )
+        post.assert_any_call(
+            "https://control.quickconnect.to/Serv.php",
+            json=[{
+                "version": 1,
+                "command": "request_tunnel",
+                "id": "mainapp_https",
+                "serverID": "my-nas",
+                "stop_when_error": False,
+                "stop_when_success": True,
+                "is_gofile": False,
+                "path": ""
+            }],
+            verify=False
+        )
+        session.get.assert_called_once_with(
+            "https://my-nas.us.quickconnect.to/webman/pingpong.cgi",
+            params=None,
+            verify=False,
+            headers={
+                "Origin": "https://my-nas.us.quickconnect.to",
+                "Referer": "https://my-nas.us.quickconnect.to"
+            }
+        )
+        login_call = session.post.call_args
+        self.assertEqual(
+            login_call.args[0],
+            "https://my-nas.us.quickconnect.to/webapi/entry.cgi"
+        )
+        self.assertEqual(login_call.kwargs["data"]["api"], "SYNO.API.Auth")
+        self.assertEqual(login_call.kwargs["data"]["ik_message"], "ik-message")
+        self.assertEqual(login_call.kwargs["verify"], False)
+        self.assertEqual(
+            login_call.kwargs["headers"],
+            {
+                "Origin": "https://my-nas.us.quickconnect.to",
+                "Referer": "https://my-nas.us.quickconnect.to"
+            }
+        )
+
+    @patch.object(Authentication, "get_ik_message", return_value="ik-message")
+    @patch("synology_api.auth.requests.Session")
+    @patch("synology_api.auth.requests.post")
+    def test_request_data_uses_quickconnect_session_headers(self, post, session_class, _get_ik):
+        session = MagicMock()
+        session.get.side_effect = [
+            FakeResponse({"success": True}),
+            FakeResponse({"success": True, "data": {"hostname": "nas"}})
+        ]
+        session.post.return_value = FakeResponse({
+            "success": True,
+            "data": {"sid": "sid-123", "synotoken": "token-123"}
+        })
+        session_class.return_value = session
+        post.side_effect = _quickconnect_post_responses()
+
+        auth = Authentication(
+            username="user",
+            password="pass",
+            quickconnect_id="my-nas",
+            cert_verify=False,
+            debug=False
+        )
+        auth.login()
+        response = auth.request_data(
+            "SYNO.FileStation.Info",
+            "entry.cgi",
+            {"version": 2, "method": "get"}
+        )
+
+        self.assertEqual(response["data"]["hostname"], "nas")
+        request_call = session.get.call_args_list[1]
+        self.assertEqual(
+            request_call.args[0],
+            "https://my-nas.us.quickconnect.to/webapi/entry.cgi?api=SYNO.FileStation.Info"
+        )
+        self.assertEqual(
+            request_call.kwargs["params"],
+            {"version": 2, "method": "get", "_sid": "sid-123"}
+        )
+        self.assertEqual(
+            request_call.kwargs["headers"],
+            {
+                "Origin": "https://my-nas.us.quickconnect.to",
+                "Referer": "https://my-nas.us.quickconnect.to",
+                "X-SYNO-TOKEN": "token-123"
+            }
+        )
+
+    @patch("synology_api.base_api.syn.Authentication")
+    def test_base_api_accepts_quickconnect_without_ip_or_port(self, auth_class):
+        session = MagicMock()
+        session.app_api_list = {"SYNO.Core.System": {"path": "entry.cgi"}}
+        session.full_api_list = {"SYNO.API.Info": {"path": "query.cgi"}}
+        session.sid = "sid-123"
+        session.base_url = "https://my-nas.us.quickconnect.to/webapi/"
+        auth_class.return_value = session
+
+        api = BaseApi(
+            username="user",
+            password="pass",
+            quickconnect_id="my-nas"
+        )
+
+        self.assertIs(api.session, session)
+        auth_class.assert_called_once_with(
+            None,
+            None,
+            "user",
+            "pass",
+            False,
+            False,
+            7,
+            True,
+            None,
+            None,
+            None,
+            "my-nas"
+        )
+        session.login.assert_called_once()
+        session.get_api_list.assert_any_call("Core")
+        session.get_api_list.assert_any_call()
+
+    @patch("synology_api.filestation.base_api.BaseApi.__init__", autospec=True)
+    def test_filestation_passes_quickconnect_to_base_api(self, base_init):
+        def fake_base_init(instance, *args, **kwargs):
+            session = MagicMock()
+            session.app_api_list = {}
+            session.request_data = MagicMock()
+            instance.session = session
+            instance.request_data = session.request_data
+            instance.core_list = {}
+            instance.gen_list = {}
+            instance._sid = "sid-123"
+            instance.base_url = "https://my-nas.us.quickconnect.to/webapi/"
+
+        base_init.side_effect = fake_base_init
+
+        FileStation(
+            username="user",
+            password="pass",
+            quickconnect_id="my-nas"
+        )
+
+        base_init.assert_called_once_with(
+            ANY,
+            None,
+            None,
+            "user",
+            "pass",
+            False,
+            False,
+            7,
+            True,
+            None,
+            None,
+            None,
+            "FileStation",
+            quickconnect_id="my-nas"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## :card_file_box: Summary

Add QuickConnect transport support so callers can connect with a NAS QuickConnect ID instead of an IP address and port.

---

## :rocket: Motivation & Problem Statement

Closes #283. The wrapper currently assumes direct DSM access through `ip_address` and `port`, but QuickConnect users need the client to resolve Synology's relay information, prime the relay session, and then send normal DSM API requests through the relay URL.

---

## :wrench: Implementation Details

- Added QuickConnect relay discovery, tunnel resolution, ping/pong cookie priming, and relay headers to `synology_api/auth.py`.
- Added `quickconnect_id` initialization support to `BaseApi` so `ip_address` and `port` are not required when QuickConnect is used.
- Passed `quickconnect_id` through the explicit constructors for FileStation, DownloadStation, Photos, Virtualization, and Certificate.
- Added mocked request-contract tests in `tests/test_quickconnect.py` for relay discovery, login, request headers, and constructor plumbing.
- Updated README, BaseApi docs, and Getting Started usage docs with QuickConnect examples.

---

## :checkered_flag: Checklist

- [x] I have read and followed the [Contributing guidelines](CONTRIBUTING.md).
- [x] All new or modified code is covered by unit tests (`tests/`).
- [x] Tests pass locally (`pytest`).
- [x] I added or updated documentation where necessary.
- [ ] I updated the changelog or added a new section if this is a major change.
- [x] I followed the style guidelines (`black`, `flake8`, etc.).
- [x] I ran `pre-commit` and addressed any linting issues.

---

## :memo: Related Issue

Closes #283

---

## :hammer: Additional Notes

- The QuickConnect flow is covered with mocked request-contract tests rather than a live QuickConnect smoke because it requires real NAS credentials and an enabled QuickConnect ID.
- The existing live `tests/test_core_user.py::TestCoreUser::test_core_user` was not run because it creates, renames, deletes a real NAS user and changes group membership.

---

## :sunglasses: Test & Build Status

```text
.venv/bin/python -m pytest tests/test_quickconnect.py -q
4 passed

.venv/bin/python -m pytest tests/test_quickconnect.py tests/test_core_*.py tests/test_vpn.py tests/test_docker_api.py --deselect tests/test_core_user.py::TestCoreUser::test_core_user -q
479 passed, 1 deselected

pre-commit run --all-files
passed

git diff --check
passed
```

---

## :eyes: Screenshots / Media

Not applicable.
