### PR TITLE
Fix certificate assignment for non-default services

### DIFF
--- a/synology_api/core_certificate.py
+++ b/synology_api/core_certificate.py
@@ -265,12 +265,16 @@ class Certificate(base_api.BaseApi):
         # retrieve existing certificates
         certs = self.list_cert()['data']['certificates']
         old_certid = ""
+        target_service = None
         for cert in certs:
             for service in cert['services']:
                 # look for the previous cert
                 if service['display_name'] == service_name:
                     old_certid = cert['id']
+                    target_service = service
                     break
+            if target_service is not None:
+                break
 
         # we need to abort, if the certificate is already set, otherwise DSM6 just removes the whole default service...
         if old_certid == cert_id:
@@ -297,11 +301,21 @@ class Certificate(base_api.BaseApi):
             }
         }
 
+        service_payload = servicedatadict.get(service_name)
+        if service_payload is None:
+            service_payload = target_service
+        if service_payload is None:
+            raise ValueError(
+                f"Service {service_name} not found in certificate service list.")
+        service_payload = {
+            **service_payload,
+            **(servicedatadictdsm7.get(service_name, {}) if (self.session._version == 7) else {})
+        }
+
         # construct the payload
         payloaddict = {
             "settings": json.dumps([{
-                "service": {**servicedatadict[service_name],
-                            **(servicedatadictdsm7[service_name] if (self.session._version == 7) else {})},
+                "service": service_payload,
                 "old_id": f"{old_certid}",
                 "id": f"{cert_id}"
             }], separators=(',', ':')),

--- a/tests/test_core_certificate.py
+++ b/tests/test_core_certificate.py
@@ -1,0 +1,121 @@
+"""Unit tests for core_certificate."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from synology_api.core_certificate import Certificate
+
+
+def _make_instance(certs, dsm_version=7):
+    """Create a Certificate instance with mocked auth/session."""
+    with patch('synology_api.core_certificate.base_api.BaseApi.__init__', return_value=None):
+        instance = Certificate.__new__(Certificate)
+
+    session = MagicMock()
+    session.app_api_list = {
+        'SYNO.Core.Certificate.Service': {
+            'path': 'entry.cgi',
+            'minVersion': 1,
+        }
+    }
+    session._version = dsm_version
+    session._syno_token = 'token'
+    session.verify_cert_enabled.return_value = False
+
+    instance.session = session
+    instance.base_url = 'https://nas.example/webapi/'
+    instance._sid = 'sid'
+    instance._debug = False
+    instance.list_cert = MagicMock(
+        return_value={'data': {'certificates': certs}})
+    return instance
+
+
+def _post_settings(mock_requests_session):
+    post_call = mock_requests_session.return_value.post.call_args
+    return json.loads(post_call.kwargs['data']['settings'])
+
+
+class TestCoreCertificate(unittest.TestCase):
+    """Tests for Certificate methods."""
+
+    def test_set_certificate_for_default_service_keeps_dsm7_payload(self):
+        certs = [{
+            'id': 'old-cert',
+            'services': [{'display_name': 'DSM Desktop Service'}],
+        }]
+        instance = _make_instance(certs)
+
+        with patch('synology_api.core_certificate.requests.session') as mock_session:
+            mock_session.return_value.post.return_value.status_code = 200
+            mock_session.return_value.post.return_value.json.return_value = {
+                'success': True}
+            status_code, response = instance.set_certificate_for_service(
+                'new-cert')
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(response, {'success': True})
+        settings = _post_settings(mock_session)
+        self.assertEqual(settings[0]['old_id'], 'old-cert')
+        self.assertEqual(settings[0]['id'], 'new-cert')
+        self.assertEqual(
+            settings[0]['service']['display_name'], 'DSM Desktop Service')
+        self.assertEqual(settings[0]['service']['service'], 'default')
+        self.assertTrue(settings[0]['service']['multiple_cert'])
+        self.assertTrue(settings[0]['service']['user_setable'])
+
+    def test_set_certificate_for_non_default_service_uses_discovered_service(self):
+        reverse_proxy_service = {
+            'display_name': 'Reverse Proxy - photos.example.com',
+            'display_name_i18n': 'reverse_proxy:photos.example.com',
+            'isPkg': False,
+            'owner': 'root',
+            'service': 'ReverseProxy_1',
+            'subscriber': 'reverse_proxy',
+            'multiple_cert': True,
+            'user_setable': True,
+        }
+        certs = [{
+            'id': 'old-cert',
+            'services': [reverse_proxy_service],
+        }]
+        instance = _make_instance(certs)
+
+        with patch('synology_api.core_certificate.requests.session') as mock_session:
+            mock_session.return_value.post.return_value.status_code = 200
+            mock_session.return_value.post.return_value.json.return_value = {
+                'success': True}
+            status_code, response = instance.set_certificate_for_service(
+                'new-cert', 'Reverse Proxy - photos.example.com')
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(response, {'success': True})
+        settings = _post_settings(mock_session)
+        self.assertEqual(settings[0]['old_id'], 'old-cert')
+        self.assertEqual(settings[0]['id'], 'new-cert')
+        self.assertEqual(settings[0]['service'], reverse_proxy_service)
+
+    def test_set_certificate_for_missing_service_raises_clear_error(self):
+        certs = [{'id': 'old-cert', 'services': []}]
+        instance = _make_instance(certs)
+
+        with self.assertRaisesRegex(ValueError, 'Service Missing Service not found'):
+            instance.set_certificate_for_service('new-cert', 'Missing Service')
+
+    def test_set_certificate_for_service_aborts_when_already_set(self):
+        certs = [{
+            'id': 'same-cert',
+            'services': [{'display_name': 'DSM Desktop Service'}],
+        }]
+        instance = _make_instance(certs)
+
+        with patch('synology_api.core_certificate.requests.session') as mock_session:
+            result = instance.set_certificate_for_service('same-cert')
+
+        self.assertEqual(result, (200, 'Certificate already set, aborting'))
+        mock_session.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## :card_file_box: Summary

Fix certificate assignment for DSM services that are discovered from the live certificate service list instead of the static service map.

---

## :rocket: Motivation & Problem Statement

`Certificate.set_certificate_for_service()` currently indexes a hardcoded service dictionary by `service_name`. That works for `DSM Desktop Service`, but it fails for non-default DSM services such as reverse proxy certificate assignments because those service entries are returned by DSM at runtime and are not present in the static map.

---

## :wrench: Implementation Details

- Modified `synology_api/core_certificate.py` so `set_certificate_for_service()` captures the matching service object while scanning `list_cert()`.
- Kept the existing static payload behavior for known services such as `DSM Desktop Service`.
- Added a fallback that uses the DSM-discovered service definition for non-default services.
- Added a clear `ValueError` when the requested service is not present in the certificate service list.
- Added focused unit tests in `tests/test_core_certificate.py` for default service behavior, discovered non-default service behavior, missing service errors, and already-assigned no-op behavior.

---

## :checkered_flag: Checklist

- [x] I have read and followed the [Contributing guidelines](CONTRIBUTING.md).
- [x] All new or modified code is covered by unit tests (`tests/`).
- [x] Tests pass locally (`pytest`).
- [x] I added or updated documentation where necessary.
- [ ] I updated the changelog or added a new section if this is a major change.
- [x] I followed the style guidelines (`black`, `flake8`, etc.).
- [ ] I ran `pre-commit` and addressed any linting issues.

`pre-commit` is not installed in the project venv used for local verification, so I could not run it locally. The GitHub `pre-commit` workflow is running on this PR.

---

## :memo: Related Issue

Closes #341.

---

## :hammer: Additional Notes

Live DSM verification was performed against reverse proxy certificate assignment:

- Created a temporary reverse proxy service.
- Changed its certificate assignment.
- Verified the new assignment was reflected by DSM.
- Restored the original certificate assignment.
- Deleted the temporary reverse proxy service.

The marked safe integration tests currently fail for me even on clean `upstream/master` against my NAS, so I am treating those as existing environment/API-version drift rather than part of this change.

---

## :sunglasses: Test & Build Status

```bash
python -m pytest tests/test_core_certificate.py tests/test_core_service_apps.py -q
# 64 passed in 0.09s

git diff --check
# passed
```

Attempted but unavailable locally:

```bash
pre-commit run --all-files
# no such file or directory

python -m pre_commit run --all-files
# No module named pre_commit
```

---

## :eyes: Screenshots / Media

Not applicable.

---

Thank you for contributing!
