### PR TITLE
Use secrets module for AES passphrase generation

### DIFF
--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -1,6 +1,6 @@
 """Provides authentication and API request handling for Synology DSM, including session management, encryption utilities, and error handling for various Synology services."""
 from __future__ import annotations
-from random import randint
+import secrets
 from typing import Optional, Any, Union
 import requests
 import json
@@ -437,7 +437,7 @@ class Authentication:
         key = b''
 
         while length > 0:
-            key += available[randint(0, len(available) - 1)].encode('utf-8')
+            key += secrets.choice(available).encode('utf-8')
             length -= 1
 
         return key


### PR DESCRIPTION
## Summary

`Authentication._random_AES_passphrase` produces the AES passphrase that `encrypt_params` uses, via OpenSSL `EVP_BytesToKey`, to derive the AES-256-CBC key and IV protecting request parameters.

It currently draws characters via `random.randint`, which is backed by the process-global Mersenne Twister PRNG and is not intended for cryptographic key material.

This PR switches the function to `secrets.choice` — the standard-library CSPRNG — while preserving the existing character set.

## Changes

- Replace `from random import randint` with `import secrets`.
- Reimplement `_random_AES_passphrase` using `secrets.choice`.

## Compatibility

This change is non-breaking:

- Wire format is unchanged: RSA-encrypted passphrase plus AES-256-CBC blob with the `Salted__` prefix.
- Passphrase length is preserved at 501 bytes, matching the RSA-4096 PKCS#1 v1.5 plaintext budget (`512 - 11`).
- Character alphabet is preserved byte-for-byte: `0-9`, `a-z`, `A-Z`, `~!@#$%^&*()_+-/`.
- Return type (`bytes`) and call sites are unchanged.

## Verification

Ran a local sanity check on the patched function:

- output length is 501 bytes;
- output is drawn only from the original alphabet;
- outputs are distinct across calls;
- return type is `bytes`.