### PR TITLE
Fix closure bug in validate_path trailing-character check

### DIFF
--- a/synology_api/utils.py
+++ b/synology_api/utils.py
@@ -205,7 +205,7 @@ def validate_path(path: str | list[str]) -> bool:
         if not path_pattern.match(single_path):
             return False
 
-        if path[-1] in (' ', '\t', '/'):
+        if single_path[-1] in (' ', '\t', '/'):
             return False
 
         parts = single_path.rsplit('.', 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,74 @@
+"""Unit tests for synology_api.utils."""
+
+import unittest
+
+from synology_api.utils import validate_path
+
+
+class ValidatePathTests(unittest.TestCase):
+    """Tests for validate_path covering both str and list inputs."""
+
+    # --- str input: positive cases ---
+
+    def test_str_valid_file(self):
+        self.assertTrue(validate_path('/Downloads/script.log'))
+
+    def test_str_valid_file_with_internal_space(self):
+        self.assertTrue(validate_path('/Downloads/script log.txt'))
+
+    def test_str_valid_extensionless(self):
+        self.assertTrue(validate_path('/Downloads/script'))
+
+    # --- str input: negative cases ---
+
+    def test_str_trailing_slash(self):
+        self.assertFalse(validate_path('/Downloads/folder/'))
+
+    def test_str_trailing_space(self):
+        self.assertFalse(validate_path('/Downloads/script.log '))
+
+    def test_str_trailing_tab(self):
+        self.assertFalse(validate_path('/Downloads/script.log\t'))
+
+    def test_str_missing_leading_slash(self):
+        self.assertFalse(validate_path('Downloads/script.log'))
+
+    def test_str_space_after_extension(self):
+        self.assertFalse(validate_path('/Downloads/script.log extra'))
+
+    # --- list input: positive cases ---
+
+    def test_list_all_valid(self):
+        self.assertTrue(validate_path(['/Downloads/a.log', '/Downloads/b.log']))
+
+    # --- list input: negative cases (these caught the closure bug) ---
+
+    def test_list_single_with_trailing_slash(self):
+        # Regression: prior to the fix, the trailing-slash check used the outer
+        # `path` (the whole list) instead of `single_path`, so this returned True.
+        self.assertFalse(validate_path(['/Downloads/folder/']))
+
+    def test_list_single_with_trailing_space(self):
+        # Regression: same closure bug — trailing-space check was skipped.
+        self.assertFalse(validate_path(['/Downloads/script.log ']))
+
+    def test_list_first_element_invalid(self):
+        # Regression: the trailing-char check looked at path[-1] (last list
+        # element), so an invalid first element could still pass the check.
+        self.assertFalse(validate_path(['/Downloads/folder/', '/Downloads/ok.log']))
+
+    def test_list_middle_element_invalid(self):
+        self.assertFalse(validate_path(['/a.log', '/bad/folder/', '/b.log']))
+
+    # --- input-type handling ---
+
+    def test_non_str_non_list_returns_false(self):
+        self.assertFalse(validate_path(123))
+        self.assertFalse(validate_path(None))
+
+    def test_list_with_non_str_element_returns_false(self):
+        self.assertFalse(validate_path(['/a.log', 42]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,8 @@ class ValidatePathTests(unittest.TestCase):
     # --- list input: positive cases ---
 
     def test_list_all_valid(self):
-        self.assertTrue(validate_path(['/Downloads/a.log', '/Downloads/b.log']))
+        self.assertTrue(validate_path(
+            ['/Downloads/a.log', '/Downloads/b.log']))
 
     # --- list input: negative cases (these caught the closure bug) ---
 
@@ -55,7 +56,8 @@ class ValidatePathTests(unittest.TestCase):
     def test_list_first_element_invalid(self):
         # Regression: the trailing-char check looked at path[-1] (last list
         # element), so an invalid first element could still pass the check.
-        self.assertFalse(validate_path(['/Downloads/folder/', '/Downloads/ok.log']))
+        self.assertFalse(validate_path(
+            ['/Downloads/folder/', '/Downloads/ok.log']))
 
     def test_list_middle_element_invalid(self):
         self.assertFalse(validate_path(['/a.log', '/bad/folder/', '/b.log']))


### PR DESCRIPTION
## Summary

`validate_path` in `synology_api/utils.py` has a closure bug in its nested `_is_valid` function.

The trailing-character check uses the outer `path` variable instead of the inner `single_path` parameter, so trailing slash, trailing space, and trailing tab validation is silently skipped when `validate_path` is called with a list of paths.

## Reproduction

```python
from synology_api.utils import validate_path

validate_path("/Downloads/folder/")      # False (correct: trailing slash)
validate_path(["/Downloads/folder/"])    # True  (BUG: should be False)
validate_path(["/a.log", "/b/folder/"])  # True  (BUG: should be False)
```

For `str` input, the bug is invisible because `path` and `single_path` refer to the same string.

For `list` input, `path[-1]` returns the last list element, which is itself a string. That value is then compared against the single-character options (`" "`, `"\t"`, `"/"`) using `in`. A multi-character string is never equal to any of those characters, so the check always evaluates to `False`.

As a result, the rule documented in the docstring — "Must not end with a space, tab, or slash" — is not enforced for list elements.

## Fix

```diff
-        if path[-1] in (" ", "\t", "/"):
+        if single_path[-1] in (" ", "\t", "/"):
             return False
```

This is a one-character-scope fix:

- no behavior change for `str` input;
- list input now correctly enforces the trailing-character rule per element.

## Tests

Adds `tests/test_utils.py` with 16 cases covering:

- `str` positive cases:
  - valid file;
  - internal-space file;
  - extensionless path;
- `str` negative cases:
  - trailing slash;
  - trailing space;
  - trailing tab;
  - missing leading slash;
  - space after extension;
- `list` positive cases:
  - all-valid list;
- `list` negative cases, including regression coverage for the closure bug:
  - single-element trailing slash;
  - single-element trailing space;
  - first-element invalid;
  - middle-element invalid;
- input-type handling:
  - non-`str` / non-`list` input returns `False`;
  - list with non-`str` element returns `False`.

All 16 cases pass on the fixed code.
