### PR TITLE
Enhance GitHub Pages workflow and fix docs generator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,4 @@
 name: Deploy to GitHub Pages
-defaults:
-  run:
-    shell: bash
-    working-directory: ./documentation
 
 on:
   push:
@@ -12,21 +8,39 @@ on:
 jobs:
   build:
     name: Build Docs
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Generate API docs markdown
+        run: python3 -m scripts.docs_parser -a -l
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
           cache-dependency-path: ./documentation/package-lock.json
 
-      - name: Install dependencies
+      - name: Install Node dependencies
         run: npm ci
-      - name: Build website
+        working-directory: ./documentation
+
+      - name: Build Docusaurus website
         run: npm run build
+        working-directory: ./documentation
 
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3
@@ -37,12 +51,10 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
 
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
+      pages: write
+      id-token: write
 
-    # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/scripts/docs_parser/markdown_generator.py
+++ b/scripts/docs_parser/markdown_generator.py
@@ -216,9 +216,10 @@ def gen_doc_metadata(class_name: str, docs_status_info: dict) -> tuple[str, str]
         try:
             status_indicator = DOCS_STATUS_INDICATOR[docs_status]
         except KeyError:
+            status_values = "', '".join(DOCS_STATUS_INDICATOR.keys())
             warnings.warn(
                 f"Unknown documentation status '{docs_status}' for class '{class_name}'. "
-                f"Possible values: '{'\', \''.join(DOCS_STATUS_INDICATOR.keys())}'. "
+                f"Possible values: '{status_values}'. "
                 f"Please update `{DOCS_TRACKER.name}` accordingly.", UserWarning)
     else:
         warnings.warn(


### PR DESCRIPTION
Update CI deploy workflow to set up Python 3.13, install Python deps, and run the docs parser to generate API markdown before building the Docusaurus site. Also add checkout permissions, move npm installs/build into the documentation working directory, and keep existing Pages deployment steps. Fix a formatting bug in markdown_generator.py by precomputing the joined possible status values to avoid escaping issues in the warning message.

﻿
