### PR TITLE
Add ctrl_led method to control camera LED

### DIFF
--- a/synology_api/surveillancestation.py
+++ b/synology_api/surveillancestation.py
@@ -7565,6 +7565,58 @@ class SurveillanceStation(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
+    def ctrl_led(self,
+                 camId: int = None,
+                 ctrlVal: bool = False) -> dict[str, object] | str:
+        """Control the white LED on a camera that supports ``ledCap``.
+
+            The camera LED status is available via
+            :meth:`camera_list` with ``optimize=True`` as
+            ``whiteLedStatus`` (0 = Off, 1 = On).
+
+            Only works on cameras that report ``ledCap`` in
+            :meth:`get_camera_info`.
+
+            Parameters
+            ----------
+            camId : int
+                Camera ID (from :meth:`camera_list`).
+
+            ctrlVal : bool, default=False
+                ``True`` to turn the LED on, ``False`` to turn it off.
+
+            Returns
+            -------
+            dict[str, object] or str
+                Result of the LED control operation or error details.
+
+            Examples
+            --------
+            ```python
+            # Turn the LED on
+            ss.ctrl_led(camId=1, ctrlVal=True)
+
+            # Turn the LED off
+            ss.ctrl_led(camId=1, ctrlVal=False)
+            ```
+
+            See Also
+            --------
+            :meth:`camera_list` : Returns ``whiteLedStatus`` when optimize=True.
+            :meth:`get_camera_info` : Returns ``ledCap`` capability flag.
+        """
+        api_name = 'SYNO.SurveillanceStation.DigitalOutput'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'],
+                     'method': 'CtrlLED',
+                     'ctrlVal': json.dumps(ctrlVal).lower()}
+
+        if camId is not None:
+            req_param['camId'] = camId
+
+        return self.request_data(api_name, api_path, req_param)
+
     def trigger_external_event(self,
                                eventId: int = None,
                                # TODO to check

--- a/synology_api/surveillancestation.py
+++ b/synology_api/surveillancestation.py
@@ -7568,42 +7568,43 @@ class SurveillanceStation(base_api.BaseApi):
     def ctrl_led(self,
                  camId: int = None,
                  ctrlVal: bool = False) -> dict[str, object] | str:
-        """Control the white LED on a camera that supports ``ledCap``.
+        """
+        Control the white LED on a camera that supports ``ledCap``.
 
-            The camera LED status is available via
-            :meth:`camera_list` with ``optimize=True`` as
-            ``whiteLedStatus`` (0 = Off, 1 = On).
+        The camera LED status is available via
+        :meth:`camera_list` with ``optimize=True`` as
+        ``whiteLedStatus`` (0 = Off, 1 = On).
 
-            Only works on cameras that report ``ledCap`` in
-            :meth:`get_camera_info`.
+        Only works on cameras that report ``ledCap`` in
+        :meth:`get_camera_info`.
 
-            Parameters
-            ----------
-            camId : int
-                Camera ID (from :meth:`camera_list`).
+        Parameters
+        ----------
+        camId : int
+            Camera ID (from :meth:`camera_list`).
 
-            ctrlVal : bool, default=False
-                ``True`` to turn the LED on, ``False`` to turn it off.
+        ctrlVal : bool, default=False
+            ``True`` to turn the LED on, ``False`` to turn it off.
 
-            Returns
-            -------
-            dict[str, object] or str
-                Result of the LED control operation or error details.
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the LED control operation or error details.
 
-            Examples
-            --------
-            ```python
-            # Turn the LED on
-            ss.ctrl_led(camId=1, ctrlVal=True)
+        Examples
+        --------
+        ```python
+        # Turn the LED on
+        ss.ctrl_led(camId=1, ctrlVal=True)
 
-            # Turn the LED off
-            ss.ctrl_led(camId=1, ctrlVal=False)
-            ```
+        # Turn the LED off
+        ss.ctrl_led(camId=1, ctrlVal=False)
+        ```
 
-            See Also
-            --------
-            :meth:`camera_list` : Returns ``whiteLedStatus`` when optimize=True.
-            :meth:`get_camera_info` : Returns ``ledCap`` capability flag.
+        See Also
+        --------
+        :meth:`camera_list` : Returns ``whiteLedStatus`` when optimize=True.
+        :meth:`get_camera_info` : Returns ``ledCap`` capability flag.
         """
         api_name = 'SYNO.SurveillanceStation.DigitalOutput'
         info = self.gen_list[api_name]

--- a/synology_api/surveillancestation.py
+++ b/synology_api/surveillancestation.py
@@ -7591,6 +7591,11 @@ class SurveillanceStation(base_api.BaseApi):
         dict[str, object] or str
             Result of the LED control operation or error details.
 
+        See Also
+        --------
+        :meth:`camera_list` : Returns ``whiteLedStatus`` when optimize=True.
+        :meth:`get_camera_info` : Returns ``ledCap`` capability flag.
+
         Examples
         --------
         ```python
@@ -7600,11 +7605,6 @@ class SurveillanceStation(base_api.BaseApi):
         # Turn the LED off
         ss.ctrl_led(camId=1, ctrlVal=False)
         ```
-
-        See Also
-        --------
-        :meth:`camera_list` : Returns ``whiteLedStatus`` when optimize=True.
-        :meth:`get_camera_info` : Returns ``ledCap`` capability flag.
         """
         api_name = 'SYNO.SurveillanceStation.DigitalOutput'
         info = self.gen_list[api_name]


### PR DESCRIPTION
Add ctrl_led to the SurveillanceStation API wrapper to control a camera's white LED (for cameras that report 'ledCap'). The method calls SYNO.SurveillanceStation.DigitalOutput with method 'CtrlLED', uses the API's maxVersion, accepts optional camId and a boolean ctrlVal (encoded via json.dumps(...).lower()), and forwards parameters to request_data. Includes a docstring with parameter details, examples, and references to camera_list and get_camera_info. this closes #354
