### PR TITLE
Add numerous Synology API wrapper methods

### DIFF
--- a/synology_api/audiostation.py
+++ b/synology_api/audiostation.py
@@ -183,3 +183,51 @@ class AudioStation(base_api.BaseApi):
                      'version': info['maxVersion'], 'action': 'prev'}
 
         return self.request_data(api_name, api_path, req_param)
+
+    def audiostream_stream(self, id: str) -> dict:
+        """
+        SYNO.AudioPlayer.Stream.stream
+
+        Parameters
+        ----------
+        id : str
+            Media ID to stream (from ``list_media_info``).
+
+        Returns
+        -------
+        dict
+            Stream URL and metadata.
+        """
+        api_name = "SYNO.AudioPlayer.Stream"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "stream",
+            "version": 2,
+            "id": id,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def audiostream_transcode(self, id: str) -> dict:
+        """
+        SYNO.AudioPlayer.Stream.transcode
+
+        Parameters
+        ----------
+        id : str
+            Media ID to transcode (from ``list_media_info``).
+
+        Returns
+        -------
+        dict
+            Transcode stream URL and metadata.
+        """
+        api_name = "SYNO.AudioPlayer.Stream"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "transcode",
+            "version": 2,
+            "id": id,
+        }
+        return self.request_data(api_name, api_path, req_param)

--- a/synology_api/audiostation.py
+++ b/synology_api/audiostation.py
@@ -186,7 +186,7 @@ class AudioStation(base_api.BaseApi):
 
     def audiostream_stream(self, id: str) -> dict:
         """
-        SYNO.AudioPlayer.Stream.stream
+        Start audio streaming for a given media ID.
 
         Parameters
         ----------
@@ -210,7 +210,7 @@ class AudioStation(base_api.BaseApi):
 
     def audiostream_transcode(self, id: str) -> dict:
         """
-        SYNO.AudioPlayer.Stream.transcode
+        Transcode an audio stream to a different format.
 
         Parameters
         ----------

--- a/synology_api/core_backup.py
+++ b/synology_api/core_backup.py
@@ -531,3 +531,1258 @@ class Backup(base_api.BaseApi):
             'filter_target_id': target_id
         }
         return self.request_data(api_name, api_path, req_param)
+
+    def backup_app_get_icon(self) -> dict:
+        """
+        Get the Hyper Backup application icon.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.App``.
+        """
+        api_name = "SYNO.Backup.App"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_icon",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def backup_app_list(self) -> dict:
+        """
+        List all backup tasks currently configured in Hyper Backup.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.App.Backup``.
+        """
+        api_name = "SYNO.Backup.App.Backup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def backup_app_mysql_check(self) -> dict:
+        """
+        Check whether MySQL/MariaDB backup support is available on the NAS.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.App.Backup``.
+        """
+        api_name = "SYNO.Backup.App.Backup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "mysql_check",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def backup_app_surveillance_check(self) -> dict:
+        """
+        Check whether Surveillance Station backup support is available on the NAS.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.App.Backup``.
+        """
+        api_name = "SYNO.Backup.App.Backup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "surveillance_check",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_app_list(self) -> dict:
+        """
+        List available restore points/tasks in Hyper Backup.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.App.Restore``.
+        """
+        api_name = "SYNO.Backup.App.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_app_mysql_check(self) -> dict:
+        """
+        Check whether MySQL/MariaDB restore capability is available.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.App.Restore``.
+        """
+        api_name = "SYNO.Backup.App.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "mysql_check",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_app_surveillance_check(self) -> dict:
+        """
+        Check whether Surveillance Station restore capability is available.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.App.Restore``.
+        """
+        api_name = "SYNO.Backup.App.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "surveillance_check",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_backup(self) -> dict:
+        """
+        Trigger an automatic backup based on the configured schedule.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "backup",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_download_private_key(self) -> dict:
+        """
+        Download the private key used for encrypted backup archives.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "download_private_key",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_get(self) -> dict:
+        """
+        Get the current auto-backup configuration (schedule, targets, encryption).
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_get_meta(self) -> dict:
+        """
+        Get metadata about the auto-backup configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_meta",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_list(self) -> dict:
+        """
+        List all auto-backup configuration entries.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_restore(self) -> dict:
+        """
+        Restore system configuration from an auto-backup archive.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "restore",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_set(self) -> dict:
+        """
+        Set or update the auto-backup configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_status(self) -> dict:
+        """
+        Get the current status of auto-backup operations.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "status",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def autobackup_config_upload_private_key(self) -> dict:
+        """
+        Upload a private key for encrypting future auto-backup archives.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.AutoBackup``.
+        """
+        api_name = "SYNO.Backup.Config.AutoBackup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "upload_private_key",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def backup_config_download(self) -> dict:
+        """
+        Download a system configuration backup archive.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Backup``.
+        """
+        api_name = "SYNO.Backup.Config.Backup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "download",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def backup_config_list(self) -> dict:
+        """
+        List available system configuration backup archives.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Backup``.
+        """
+        api_name = "SYNO.Backup.Config.Backup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def backup_config_start(self) -> dict:
+        """
+        Start a system configuration backup immediately.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Backup``.
+        """
+        api_name = "SYNO.Backup.Config.Backup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "start",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def backup_config_status(self) -> dict:
+        """
+        Get the status of a system configuration backup operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Backup``.
+        """
+        api_name = "SYNO.Backup.Config.Backup"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "status",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_config_check(self) -> dict:
+        """
+        Verify the integrity and compatibility of a restore archive.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Restore``.
+        """
+        api_name = "SYNO.Backup.Config.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_config_delete(self) -> dict:
+        """
+        Delete a saved system configuration restore archive.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Restore``.
+        """
+        api_name = "SYNO.Backup.Config.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "delete",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_config_list(self) -> dict:
+        """
+        List available system configuration restore archives.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Restore``.
+        """
+        api_name = "SYNO.Backup.Config.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_config_list_conflict(self) -> dict:
+        """
+        List any conflicts detected in a restore archive.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Restore``.
+        """
+        api_name = "SYNO.Backup.Config.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list_conflict",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_config_start(self) -> dict:
+        """
+        Start a system configuration restore operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Restore``.
+        """
+        api_name = "SYNO.Backup.Config.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "start",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_config_status(self) -> dict:
+        """
+        Get the status of a restore operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Restore``.
+        """
+        api_name = "SYNO.Backup.Config.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "status",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def restore_config_upload(self) -> dict:
+        """
+        Upload a system configuration archive for restore.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Backup.Config.Restore``.
+        """
+        api_name = "SYNO.Backup.Config.Restore"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "upload",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+
+class S2SServer(base_api.BaseApi):
+    """Synology S2S (Server-to-Server) backup API wrapper."""
+
+    def s2s_server_get(self) -> dict:
+        """
+        Get the current Server-to-Server backup server configuration (task list, schedule, targets).
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.S2S.Server``.
+        """
+        api_name = "SYNO.S2S.Server"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def s2s_server_set(self) -> dict:
+        """
+        Set or update the Server-to-Server backup server configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.S2S.Server``.
+        """
+        api_name = "SYNO.S2S.Server"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+
+# ------------------------------------------------------------------
+# Disaster Recovery / Snapshot Replication
+# ------------------------------------------------------------------
+
+
+class DRNode(base_api.BaseApi):
+    """Synology Disaster Recovery / Snapshot Replication API wrapper."""
+
+    def dr_node_check_and_reset(self) -> dict:
+        """
+        Check the DR node status and reset if needed (used during setup/recovery).
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_and_reset",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_node_get_net_info(self) -> dict:
+        """
+        Get network information for the local DR node.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_net_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_node_get_remote_net_info(self) -> dict:
+        """
+        Get network information for the remote DR partner node.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_remote_net_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_node_info(self) -> dict:
+        """
+        Get general information and status of the DR node.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_node_reset(self) -> dict:
+        """
+        Reset the DR node configuration to factory defaults.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "reset",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_node_test_connection(self) -> dict:
+        """
+        Test the network connection to the remote DR partner node.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "test_connection",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_node_test_download_speed(self) -> dict:
+        """
+        Run a download speed test to the remote DR partner.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "test_download_speed",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_node_test_privilege(self) -> dict:
+        """
+        Verify that the DR node has sufficient privileges for replication.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "test_privilege",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_node_test_sync_speed(self) -> dict:
+        """
+        Run a sync speed benchmark between local and remote DR nodes.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node``.
+        """
+        api_name = "SYNO.DR.Node"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "test_sync_speed",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_create(self) -> dict:
+        """
+        Create credentials for authenticating with a remote DR partner node.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_delete(self) -> dict:
+        """
+        Delete stored DR partner credentials.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "delete",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_get(self) -> dict:
+        """
+        Get the current DR partner credential details.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_list(self) -> dict:
+        """
+        List all stored DR partner credentials.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_relay(self) -> dict:
+        """
+        Relay/forward credentials through an intermediate DR node.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "relay",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_reverse_create(self) -> dict:
+        """
+        Create reverse credentials so the partner node can authenticate back.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "reverse_create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_set(self) -> dict:
+        """
+        Set or update DR partner credentials.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_temp_create(self) -> dict:
+        """
+        Create temporary credentials for one-time DR operations.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "temp_create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_temp_reverse_create(self) -> dict:
+        """
+        Create temporary reverse credentials for partner node.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "temp_reverse_create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_test_create(self) -> dict:
+        """
+        Test-validate credential creation parameters before committing.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "test_create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_test_reverse_create(self) -> dict:
+        """
+        Test-validate reverse credential parameters before committing.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "test_reverse_create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_credential_test_set(self) -> dict:
+        """
+        Test-validate credential update parameters before committing.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Credential``.
+        """
+        api_name = "SYNO.DR.Node.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "test_set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_session_create(self) -> dict:
+        """
+        Create a new DR replication session with the partner node.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Session``.
+        """
+        api_name = "SYNO.DR.Node.Session"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "create",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_session_delete(self) -> dict:
+        """
+        Delete/terminate an existing DR replication session.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Session``.
+        """
+        api_name = "SYNO.DR.Node.Session"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "delete",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_session_find(self) -> dict:
+        """
+        Find and enumerate active DR replication sessions.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Session``.
+        """
+        api_name = "SYNO.DR.Node.Session"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "find",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_session_get(self) -> dict:
+        """
+        Get details and status of a specific DR replication session.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Session``.
+        """
+        api_name = "SYNO.DR.Node.Session"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_session_temp_create(self) -> dict:
+        """
+        Create a temporary DR session for testing or one-off sync.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DR.Node.Session``.
+        """
+        api_name = "SYNO.DR.Node.Session"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "temp_create",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_log_clear(self) -> dict:
+        """
+        Clear all entries from the Disaster Recovery log.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Log``.
+        """
+        api_name = "SYNO.DisasterRecovery.Log"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "clear",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_log_export(self) -> dict:
+        """
+        Export the Disaster Recovery log to a downloadable file.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Log``.
+        """
+        api_name = "SYNO.DisasterRecovery.Log"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "export",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_log_list(self) -> dict:
+        """
+        List all entries in the Disaster Recovery log.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Log``.
+        """
+        api_name = "SYNO.DisasterRecovery.Log"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_check_worm_lockable(self) -> dict:
+        """
+        Check whether a snapshot can be WORM-locked (Write Once Read Many).
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_worm_lockable",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_clear_worm_lock_notify_time(self) -> dict:
+        """
+        Clear the WORM lock expiration notification timer.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "clear_worm_lock_notify_time",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_delete(self) -> dict:
+        """
+        Delete a retention policy entry.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "delete",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_get(self) -> dict:
+        """
+        Get the current snapshot retention policy configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_get_timezone(self) -> dict:
+        """
+        Get the timezone used for retention policy scheduling.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_timezone",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_get_worm_lock(self) -> dict:
+        """
+        Get the WORM lock configuration for protected snapshots.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_worm_lock",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_info(self) -> dict:
+        """
+        Get general information about the retention policy settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_notify_worm_lock_disable(self) -> dict:
+        """
+        Disable WORM lock expiration notifications.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "notify_worm_lock_disable",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_set(self) -> dict:
+        """
+        Set or update the snapshot retention policy.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_set_timezone(self) -> dict:
+        """
+        Set the timezone used for retention policy scheduling.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_timezone",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dr_retention_set_worm_lock(self) -> dict:
+        """
+        Enable/configure WORM lock protection for snapshots.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DisasterRecovery.Retention``.
+        """
+        api_name = "SYNO.DisasterRecovery.Retention"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_worm_lock",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)

--- a/synology_api/core_certificate.py
+++ b/synology_api/core_certificate.py
@@ -389,3 +389,105 @@ class Certificate(base_api.BaseApi):
             return BytesIO(result.content)
 
         return
+
+    def cert_crt_create(self) -> dict:
+        """Create a new SSL/TLS certificate or certificate signing request (CSR).
+
+        Returns
+        -------
+        dict
+            API response with the created certificate/CSR details.
+        """
+        api_name = "SYNO.Core.Certificate.CRT"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cert_crt_delete(self) -> dict:
+        """Delete a stored certificate or certificate signing request.
+
+        Returns
+        -------
+        dict
+            API response confirming the deletion.
+        """
+        api_name = "SYNO.Core.Certificate.CRT"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "delete",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cert_crt_list(self) -> dict:
+        """List all SSL/TLS certificates and certificate signing requests.
+
+        Returns
+        -------
+        dict
+            API response with the list of certificates and CSRs.
+        """
+        api_name = "SYNO.Core.Certificate.CRT"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cert_crt_recreate(self) -> dict:
+        """Regenerate a certificate signing request (CSR) with new parameters.
+
+        Returns
+        -------
+        dict
+            API response with the regenerated CSR details.
+        """
+        api_name = "SYNO.Core.Certificate.CRT"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "recreate",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cert_crt_renew(self) -> dict:
+        """Renew an existing SSL/TLS certificate before expiration.
+
+        Returns
+        -------
+        dict
+            API response with the renewed certificate details.
+        """
+        api_name = "SYNO.Core.Certificate.CRT"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "renew",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cert_crt_set(self) -> dict:
+        """Set a certificate as the default or configure its properties.
+
+        Returns
+        -------
+        dict
+            API response confirming the certificate configuration.
+        """
+        api_name = "SYNO.Core.Certificate.CRT"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)

--- a/synology_api/core_certificate.py
+++ b/synology_api/core_certificate.py
@@ -282,7 +282,8 @@ class Certificate(base_api.BaseApi):
             if target_service is not None:
                 break
 
-        # we need to abort, if the certificate is already set, otherwise DSM6 just removes the whole default service...
+        # we need to abort, if the certificate is already set, otherwise DSM6
+        # just removes the whole default service...
         if old_certid == cert_id:
             if self._debug is True:
                 print('Certificate already set, aborting')
@@ -391,7 +392,8 @@ class Certificate(base_api.BaseApi):
         return
 
     def cert_crt_create(self) -> dict:
-        """Create a new SSL/TLS certificate or certificate signing request (CSR).
+        """
+        Create a new SSL/TLS certificate or certificate signing request (CSR).
 
         Returns
         -------
@@ -408,7 +410,8 @@ class Certificate(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def cert_crt_delete(self) -> dict:
-        """Delete a stored certificate or certificate signing request.
+        """
+        Delete a stored certificate or certificate signing request.
 
         Returns
         -------
@@ -425,7 +428,8 @@ class Certificate(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def cert_crt_list(self) -> dict:
-        """List all SSL/TLS certificates and certificate signing requests.
+        """
+        List all SSL/TLS certificates and certificate signing requests.
 
         Returns
         -------
@@ -442,7 +446,8 @@ class Certificate(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def cert_crt_recreate(self) -> dict:
-        """Regenerate a certificate signing request (CSR) with new parameters.
+        """
+        Regenerate a certificate signing request (CSR) with new parameters.
 
         Returns
         -------
@@ -459,7 +464,8 @@ class Certificate(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def cert_crt_renew(self) -> dict:
-        """Renew an existing SSL/TLS certificate before expiration.
+        """
+        Renew an existing SSL/TLS certificate before expiration.
 
         Returns
         -------
@@ -476,7 +482,8 @@ class Certificate(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def cert_crt_set(self) -> dict:
-        """Set a certificate as the default or configure its properties.
+        """
+        Set a certificate as the default or configure its properties.
 
         Returns
         -------

--- a/synology_api/core_notification.py
+++ b/synology_api/core_notification.py
@@ -979,3 +979,21 @@ class CoreNotification(base_api.BaseApi):
             req_param['settings'] = settings
 
         return self.request_data(api_name, api_path, req_param)
+
+    def push_notification_requesttoken(self) -> dict:
+        """
+        Request a push notification authentication token.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DSM.PushNotification``.
+        """
+        api_name = "SYNO.DSM.PushNotification"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "requesttoken",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)

--- a/synology_api/core_security_auth.py
+++ b/synology_api/core_security_auth.py
@@ -95,7 +95,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def smartblock_device_delete(self, devices: list[str]) -> dict[str, object] | str:
+    def smartblock_device_delete(
+            self, devices: list[str]) -> dict[str, object] | str:
         """
         Remove devices from the SmartBlock blocked list.
 
@@ -156,7 +157,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def smartblock_trusted_set(self, entries: list[dict[str, object]]) -> dict[str, object] | str:
+    def smartblock_trusted_set(
+            self, entries: list[dict[str, object]]) -> dict[str, object] | str:
         """
         Set SmartBlock trusted list entries.
 
@@ -181,7 +183,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def smartblock_trusted_delete(self, entries: list[str]) -> dict[str, object] | str:
+    def smartblock_trusted_delete(
+            self, entries: list[str]) -> dict[str, object] | str:
         """
         Delete entries from the SmartBlock trusted list.
 
@@ -242,7 +245,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def smartblock_untrusted_set(self, entries: list[dict[str, object]]) -> dict[str, object] | str:
+    def smartblock_untrusted_set(
+            self, entries: list[dict[str, object]]) -> dict[str, object] | str:
         """
         Set SmartBlock untrusted list entries.
 
@@ -267,7 +271,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def smartblock_untrusted_delete(self, entries: list[str]) -> dict[str, object] | str:
+    def smartblock_untrusted_delete(
+            self, entries: list[str]) -> dict[str, object] | str:
         """
         Delete entries from the SmartBlock untrusted list.
 
@@ -328,7 +333,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def smartblock_user_set(self, users: list[dict[str, object]]) -> dict[str, object] | str:
+    def smartblock_user_set(
+            self, users: list[dict[str, object]]) -> dict[str, object] | str:
         """
         Set SmartBlock user-level blocks.
 
@@ -353,7 +359,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def smartblock_user_delete(self, users: list[str]) -> dict[str, object] | str:
+    def smartblock_user_delete(
+            self, users: list[str]) -> dict[str, object] | str:
         """
         Delete SmartBlock user-level blocks.
 
@@ -480,7 +487,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def otp_enforce_policy_set(self, **kwargs: object) -> dict[str, object] | str:
+    def otp_enforce_policy_set(
+            self, **kwargs: object) -> dict[str, object] | str:
         """
         Set OTP enforcement policy.
 
@@ -619,7 +627,8 @@ class CoreSecurityAuth(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def trust_device_delete(self, devices: list[str]) -> dict[str, object] | str:
+    def trust_device_delete(
+            self, devices: list[str]) -> dict[str, object] | str:
         """
         Remove devices from the trusted list.
 
@@ -686,7 +695,8 @@ class CoreSecurityAuth(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def rescue_email_get(self) -> dict[str, object] | str:
-        """Get rescue email configuration.
+        """
+        Get rescue email configuration.
 
         Returns
         -------
@@ -701,7 +711,8 @@ class CoreSecurityAuth(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def rescue_email_set(self, email: str) -> dict[str, object] | str:
-        """Set rescue email address.
+        """
+        Set rescue email address.
 
         Parameters
         ----------
@@ -716,12 +727,16 @@ class CoreSecurityAuth(base_api.BaseApi):
         api_name = 'SYNO.Auth.RescueEmail'
         info = self.gen_list[api_name]
         api_path = info['path']
-        req_param = {'version': info['maxVersion'], 'method': 'set', 'email': email}
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'set',
+            'email': email}
 
         return self.request_data(api_name, api_path, req_param)
 
     def rescue_email_verify(self, code: str) -> dict[str, object] | str:
-        """Verify rescue email with confirmation code.
+        """
+        Verify rescue email with confirmation code.
 
         Parameters
         ----------
@@ -736,7 +751,10 @@ class CoreSecurityAuth(base_api.BaseApi):
         api_name = 'SYNO.Auth.RescueEmail'
         info = self.gen_list[api_name]
         api_path = info['path']
-        req_param = {'version': info['maxVersion'], 'method': 'verify', 'code': code}
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'verify',
+            'code': code}
 
         return self.request_data(api_name, api_path, req_param)
 
@@ -744,7 +762,8 @@ class CoreSecurityAuth(base_api.BaseApi):
     # ------------------------------------------------------------------
 
     def auth_key_get(self) -> dict[str, object] | str:
-        """Get the DSM authentication key.
+        """
+        Get the DSM authentication key.
 
         Returns
         -------
@@ -759,7 +778,8 @@ class CoreSecurityAuth(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def auth_key_grant(self) -> dict[str, object] | str:
-        """Request a new authentication key grant.
+        """
+        Request a new authentication key grant.
 
         Returns
         -------
@@ -774,7 +794,8 @@ class CoreSecurityAuth(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def auth_key_code_get(self) -> dict[str, object] | str:
-        """Get the authentication key code (used in login flow).
+        """
+        Get the authentication key code (used in login flow).
 
         Returns
         -------
@@ -792,7 +813,8 @@ class CoreSecurityAuth(base_api.BaseApi):
     # ------------------------------------------------------------------
 
     def auth_type_get(self) -> dict[str, object] | str:
-        """Get available authentication types on this DSM.
+        """
+        Get available authentication types on this DSM.
 
         Returns
         -------
@@ -810,7 +832,8 @@ class CoreSecurityAuth(base_api.BaseApi):
     # ------------------------------------------------------------------
 
     def auth_redirect_uri_check(self) -> dict[str, object] | str:
-        """Check if OAuth redirect URI is configured and available.
+        """
+        Check if OAuth redirect URI is configured and available.
 
         Returns
         -------
@@ -825,7 +848,8 @@ class CoreSecurityAuth(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def auth_redirect_uri_run(self) -> dict[str, object] | str:
-        """Execute the OAuth redirect URI workflow.
+        """
+        Execute the OAuth redirect URI workflow.
 
         Returns
         -------

--- a/synology_api/core_security_auth.py
+++ b/synology_api/core_security_auth.py
@@ -2,7 +2,8 @@
 Synology Core Security (Auth/OTP/SmartBlock) API wrapper.
 
 Covers SYNO.Core.SmartBlock.*, SYNO.Core.OTP.*, TrustDevice,
-and DisableAdmin endpoints on Synology NAS devices.
+DisableAdmin, Auth.Key, Auth.Type, Auth.RedirectURI,
+and RescueEmail endpoints on Synology NAS devices.
 """
 
 from __future__ import annotations
@@ -14,7 +15,8 @@ class CoreSecurityAuth(base_api.BaseApi):
     """
     Core Security Auth API for SmartBlock/OTP/TrustDevice/DisableAdmin.
 
-    Covers SYNO.Core.SmartBlock.*, OTP.*, TrustDevice, and DisableAdmin endpoints.
+    Covers SYNO.Core.SmartBlock.*, OTP.*, TrustDevice, DisableAdmin,
+    SYNO.API.Auth.Key, Auth.Type, Auth.RedirectURI, SYNO.Auth.RescueEmail.
     """
 
     # SYNO.Core.SmartBlock
@@ -680,5 +682,159 @@ class CoreSecurityAuth(base_api.BaseApi):
         info = self.gen_list[api_name]
         api_path = info['path']
         req_param = {'version': info['maxVersion'], 'method': 'set', **kwargs}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def rescue_email_get(self) -> dict[str, object] | str:
+        """Get rescue email configuration.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Rescue email settings (verified: bool, email address if set).
+        """
+        api_name = 'SYNO.Auth.RescueEmail'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def rescue_email_set(self, email: str) -> dict[str, object] | str:
+        """Set rescue email address.
+
+        Parameters
+        ----------
+        email : str
+            Email address to use for account rescue.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the set operation.
+        """
+        api_name = 'SYNO.Auth.RescueEmail'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set', 'email': email}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def rescue_email_verify(self, code: str) -> dict[str, object] | str:
+        """Verify rescue email with confirmation code.
+
+        Parameters
+        ----------
+        code : str
+            Verification code sent to the rescue email.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Result of the verify operation.
+        """
+        api_name = 'SYNO.Auth.RescueEmail'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'verify', 'code': code}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # SYNO.API.Auth.Key
+    # ------------------------------------------------------------------
+
+    def auth_key_get(self) -> dict[str, object] | str:
+        """Get the DSM authentication key.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Authentication key data (auth_key: str).
+        """
+        api_name = 'SYNO.API.Auth.Key'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def auth_key_grant(self) -> dict[str, object] | str:
+        """Request a new authentication key grant.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Grant response from the DSM auth key service.
+        """
+        api_name = 'SYNO.API.Auth.Key'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'grant'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def auth_key_code_get(self) -> dict[str, object] | str:
+        """Get the authentication key code (used in login flow).
+
+        Returns
+        -------
+        dict[str, object] or str
+            Key code data from ``SYNO.API.Auth.Key.Code``.
+        """
+        api_name = 'SYNO.API.Auth.Key.Code'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # SYNO.API.Auth.Type
+    # ------------------------------------------------------------------
+
+    def auth_type_get(self) -> dict[str, object] | str:
+        """Get available authentication types on this DSM.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of auth types (e.g. ``[{\"type\": \"passwd\"}]``).
+        """
+        api_name = 'SYNO.API.Auth.Type'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # SYNO.API.Auth.RedirectURI
+    # ------------------------------------------------------------------
+
+    def auth_redirect_uri_check(self) -> dict[str, object] | str:
+        """Check if OAuth redirect URI is configured and available.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Redirect URI availability (available: bool, code: int).
+        """
+        api_name = 'SYNO.API.Auth.RedirectURI'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'check'}
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def auth_redirect_uri_run(self) -> dict[str, object] | str:
+        """Execute the OAuth redirect URI workflow.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Redirect URI execution result.
+        """
+        api_name = 'SYNO.API.Auth.RedirectURI'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'run'}
 
         return self.request_data(api_name, api_path, req_param)

--- a/synology_api/core_storage.py
+++ b/synology_api/core_storage.py
@@ -584,3 +584,3285 @@ class CoreStorage(base_api.BaseApi):
                      'user': user, 'enable': str(enabled).lower()}
 
         return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_check_quota(self) -> dict:
+        """
+        Check storage quota usage.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_quota",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_dry_run(self) -> dict:
+        """
+        Run a dry-run (simulation) operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "dry_run",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_get_schedule_plan(self) -> dict:
+        """
+        Get the current schedule plan.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_schedule_plan",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_get_status(self) -> dict:
+        """
+        Get the current operational status.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_status",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_get_volume_info(self) -> dict:
+        """
+        Get volume information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_volume_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_manual_dedupe(self) -> dict:
+        """
+        Manually trigger data deduplication.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "manual_dedupe",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_rescan_quota_v2(self) -> dict:
+        """
+        Rescan storage quota (version 2).
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "rescan_quota_v2",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_set_reclaim_type(self) -> dict:
+        """
+        Set the space reclamation type.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_reclaim_type",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_set_schedule_plan(self) -> dict:
+        """
+        Set or update the schedule plan.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_schedule_plan",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_set_volume_schedule_config(self) -> dict:
+        """
+        Configure the volume schedule.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_volume_schedule_config",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def btrfs_dedupe_stop(self) -> dict:
+        """
+        Stop the current operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.BtrfsDedupe``.
+        """
+        api_name = "SYNO.Storage.CGI.BtrfsDedupe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "stop",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cache_protection_disable_passive(self) -> dict:
+        """
+        Disable passive cache protection mode.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Cache.Protection``.
+        """
+        api_name = "SYNO.Storage.CGI.Cache.Protection"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "disable_passive",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cache_protection_enable_passive(self) -> dict:
+        """
+        Enable passive cache protection mode.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Cache.Protection``.
+        """
+        api_name = "SYNO.Storage.CGI.Cache.Protection"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "enable_passive",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cache_protection_get_config(self) -> dict:
+        """
+        Get the current configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Cache.Protection``.
+        """
+        api_name = "SYNO.Storage.CGI.Cache.Protection"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_config",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cache_protection_get_status(self) -> dict:
+        """
+        Get the current operational status.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Cache.Protection``.
+        """
+        api_name = "SYNO.Storage.CGI.Cache.Protection"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_status",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cache_protection_get_status_all(self) -> dict:
+        """
+        Get the status of all items.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Cache.Protection``.
+        """
+        api_name = "SYNO.Storage.CGI.Cache.Protection"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_status_all",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def cache_protection_update_config(self) -> dict:
+        """
+        Update the configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Cache.Protection``.
+        """
+        api_name = "SYNO.Storage.CGI.Cache.Protection"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "update_config",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_do_data_scrubbing(self) -> dict:
+        """
+        Start a data scrubbing operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "do_data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_do_disk_scan(self) -> dict:
+        """
+        Start a disk scan operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "do_disk_scan",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_ignore_data_scrubbing(self) -> dict:
+        """
+        Ignore/skip a data scrubbing operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "ignore_data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_is_building(self) -> dict:
+        """
+        Check if the storage is currently building/rebuilding.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "is_building",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_is_data_scrubbing(self) -> dict:
+        """
+        Check if data scrubbing is currently running.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "is_data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_reboot_after_rebuild(self) -> dict:
+        """
+        Get or configure auto-reboot after rebuild.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "reboot_after_rebuild",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_remove_ask_for_fsck(self) -> dict:
+        """
+        Clear the file-system check prompt.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove_ask_for_fsck",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_remove_ask_for_fsck_scan(self) -> dict:
+        """
+        Clear the fsck scan prompt.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove_ask_for_fsck_scan",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_remove_ask_for_remap_scan(self) -> dict:
+        """
+        Clear the remap scan prompt.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove_ask_for_remap_scan",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_remove_ask_for_wcache_lost_data_scrubbing(self) -> dict:
+        """
+        Clear the write-cache lost data scrubbing prompt.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove_ask_for_wcache_lost_data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def storage_check_should_ask_for_fsck_scan(self) -> dict:
+        """
+        Check whether an fsck scan prompt should be shown.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Check``.
+        """
+        api_name = "SYNO.Storage.CGI.Check"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "should_ask_for_fsck_scan",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def detected_pool_assemble(self) -> dict:
+        """
+        Assemble/re-assemble a detected storage pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.DetectedPool``.
+        """
+        api_name = "SYNO.Storage.CGI.DetectedPool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "assemble",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def detected_pool_remove(self) -> dict:
+        """
+        Remove a component.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.DetectedPool``.
+        """
+        api_name = "SYNO.Storage.CGI.DetectedPool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dual_enclosure_load(self) -> dict:
+        """
+        Load/retrieve all entries.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.DualEnclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.DualEnclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "load",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_exp_fw_fail_get(self) -> dict:
+        """
+        Get expansion unit firmware failure information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "exp_fw_fail_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_exp_fw_update(self) -> dict:
+        """
+        Update expansion unit firmware.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "exp_fw_update",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_exp_fw_update_cancel_notify(self) -> dict:
+        """
+        Cancel expansion unit firmware update notification.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "exp_fw_update_cancel_notify",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_exp_fw_update_list_get(self) -> dict:
+        """
+        Get the list of available expansion unit firmware updates.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "exp_fw_update_list_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_exp_fw_update_status_get(self) -> dict:
+        """
+        Get the status of expansion unit firmware update.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "exp_fw_update_status_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_is_exp_connected(self) -> dict:
+        """
+        Check if the expansion unit is connected.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "is_exp_connected",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_load(self) -> dict:
+        """
+        Load all enclosure information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "load",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_sha_exp_fw_fail_get(self) -> dict:
+        """
+        Get SHA expansion unit firmware failure information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "sha_exp_fw_fail_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_sha_exp_fw_update(self) -> dict:
+        """
+        Update SHA expansion unit firmware.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "sha_exp_fw_update",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_sha_exp_fw_update_cancel_notify(self) -> dict:
+        """
+        Cancel SHA expansion unit firmware update notification.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "sha_exp_fw_update_cancel_notify",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_sha_exp_fw_update_list_get(self) -> dict:
+        """
+        List SHA expansion unit firmware updates available.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "sha_exp_fw_update_list_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_sha_exp_fw_update_status_get(self) -> dict:
+        """
+        Get SHA expansion unit firmware update status.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "sha_exp_fw_update_status_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def enclosure_sha_is_exp_connected(self) -> dict:
+        """
+        Check if the SHA expansion unit is connected.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Enclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.Enclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "sha_is_exp_connected",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_disable(self) -> dict:
+        """
+        Disable offline volume operations.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "disable",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_enable(self) -> dict:
+        """
+        Enable the feature.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "enable",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_get_info(self) -> dict:
+        """
+        Get flash cache information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_pack_for_ma(self) -> dict:
+        """
+        Package OAuth credentials for the mail account.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "pack_for_ma",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_repair(self) -> dict:
+        """
+        Repair/recover the entity.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "repair",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_reset(self) -> dict:
+        """
+        Reset the Taipei enclosure.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "reset",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_set_autounlock_key(self) -> dict:
+        """
+        Set an auto-unlock key for the encryption vault.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_autounlock_key",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_set_for_ma(self) -> dict:
+        """
+        Set the person mail account for the Mail Account service.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_for_ma",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_sync_to_passive(self) -> dict:
+        """
+        Sync data to the passive enclosure.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "sync_to_passive",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_verify_passwd(self) -> dict:
+        """
+        Verify the encryption vault password.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "verify_passwd",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_unlock_enter_passwd(self) -> dict:
+        """
+        Enter passwd.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault.UnlockMode``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault.UnlockMode"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "enter_passwd",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_unlock_get_passwd_wrong_record(self) -> dict:
+        """
+        Get passwd wrong record.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault.UnlockMode``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault.UnlockMode"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_passwd_wrong_record",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def encryption_vault_unlock_skip_passwd(self) -> dict:
+        """
+        Skip passwd.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.EncryptionKeyVault.UnlockMode``.
+        """
+        api_name = "SYNO.Storage.CGI.EncryptionKeyVault.UnlockMode"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "skip_passwd",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_add_drive(self) -> dict:
+        """
+        Add an SSD drive to the flash cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "add_drive",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_advisor_history_get(self) -> dict:
+        """
+        Get the Security Advisor scan history.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "advisor_history_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_advisor_poll(self) -> dict:
+        """
+        Poll for Security Advisor scan progress.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "advisor_poll",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_advisor_start(self) -> dict:
+        """
+        Start a Security Advisor security scan.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "advisor_start",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_advisor_stop(self) -> dict:
+        """
+        Stop a running Security Advisor scan.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "advisor_stop",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_check_can_create(self) -> dict:
+        """
+        Check if a new user can be created.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_can_create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_check_can_lock_space(self) -> dict:
+        """
+        Check if deduplication space can be locked.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_can_lock_space",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_check_pin_metadata_and_rec_size(self) -> dict:
+        """
+        Check pinned metadata and record size settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_pin_metadata_and_rec_size",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_check_system_raid(self) -> dict:
+        """
+        Check system RAID configuration on the pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_system_raid",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_check_volume_abnormal_cant_create_cache(self) -> dict:
+        """
+        Check if a volume abnormality prevents cache creation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_volume_abnormal_cant_create_cache",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_configure(self) -> dict:
+        """
+        Configure DSM FindMe (QuickConnect) settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "configure",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_create_feasibility_hard_check(self) -> dict:
+        """
+        Run a feasibility check for pool creation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "create_feasibility_hard_check",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_enable(self) -> dict:
+        """
+        Enable a flash cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "enable",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_estimate_mem_size(self) -> dict:
+        """
+        Estimate memory requirements for pool operations.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "estimate_mem_size",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_estimate_raid_size(self) -> dict:
+        """
+        Estimate the RAID size for a pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "estimate_raid_size",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_is_redundancy_degraded(self) -> dict:
+        """
+        Check if pool redundancy is degraded.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "is_redundancy_degraded",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_remove(self) -> dict:
+        """
+        Remove SSDs from a flash cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_remove_cancel(self) -> dict:
+        """
+        Cancel a volume removal operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove_cancel",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_repair(self) -> dict:
+        """
+        Repair a flash cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "repair",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_replace(self) -> dict:
+        """
+        Replace SSDs in a flash cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "replace",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_shared_cache_config_get(self) -> dict:
+        """
+        Get the shared SSD cache configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "shared_cache_config_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def flashcache_shared_cache_config_set(self) -> dict:
+        """
+        Set the shared SSD cache configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Flashcache``.
+        """
+        api_name = "SYNO.Storage.CGI.Flashcache"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "shared_cache_config_set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_check_loop(self) -> dict:
+        """
+        Check the deduplication background loop status.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_loop",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_delete_key(self) -> dict:
+        """
+        Delete an encryption key from the vault.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "delete_key",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_erase_all_data(self) -> dict:
+        """
+        Erase all data on spare disks.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "erase_all_data",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_get(self) -> dict:
+        """
+        Get KMIP server configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_get_key_list(self) -> dict:
+        """
+        List all encryption keys in the vault.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_key_list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_get_server_hostname(self) -> dict:
+        """
+        Get the hostname of the storage server.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_server_hostname",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_get_version_info(self) -> dict:
+        """
+        Get HA license version information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_version_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_import_cert(self) -> dict:
+        """
+        Import a KMIP server certificate.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "import_cert",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_import_server_ca(self) -> dict:
+        """
+        Import the KMIP server CA certificate.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "import_server_ca",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_list_cert(self) -> dict:
+        """
+        List KMIP client certificates.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list_cert",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_remove_cert(self) -> dict:
+        """
+        Remove a KMIP certificate.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove_cert",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_renew_cert(self) -> dict:
+        """
+        Renew a KMIP certificate.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "renew_cert",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_set(self) -> dict:
+        """
+        Configure KMIP server settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_set_cert(self) -> dict:
+        """
+        Set/configure a KMIP certificate.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_cert",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_test_conn(self) -> dict:
+        """
+        Test the KMIP server connection.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "test_conn",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def kmip_transfer_data(self) -> dict:
+        """
+        Transfer volume data to another location.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.KMIP``.
+        """
+        api_name = "SYNO.Storage.CGI.KMIP"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "transfer_data",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_cancel_data_scrubbing(self) -> dict:
+        """
+        Cancel an ongoing data scrubbing operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "cancel_data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_check_fast_repair(self) -> dict:
+        """
+        Check if a fast repair is possible on the pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "check_fast_repair",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_create(self) -> dict:
+        """
+        Create a new storage pool on the NAS.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_data_scrubbing(self) -> dict:
+        """
+        Get/set data scrubbing status for the pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_data_scrubbing_plain(self) -> dict:
+        """
+        Run a plain data scrubbing operation (no dedupe).
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "data_scrubbing_plain",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_deactivate(self) -> dict:
+        """
+        Deactivate the flash cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "deactivate",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_delete(self) -> dict:
+        """
+        Delete an existing storage pool (destructive — all data lost).
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "delete",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_edit_desc(self) -> dict:
+        """
+        Edit the description of a user account.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "edit_desc",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_enum_resource(self) -> dict:
+        """
+        Enumerate resources within a storage pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "enum_resource",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_estimate_size(self) -> dict:
+        """
+        Estimate the resulting size after pool expansion.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "estimate_size",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_expand_by_add_disk(self) -> dict:
+        """
+        Expand a storage pool by adding new disks.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "expand_by_add_disk",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_expand_unallocated(self) -> dict:
+        """
+        Expand a pool using unallocated space.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "expand_unallocated",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_expand_unfinished_shr(self) -> dict:
+        """
+        Resume an interrupted SHR expansion.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "expand_unfinished_shr",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_get_setting(self) -> dict:
+        """
+        Get the flash cache settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_setting",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_is_disk_detected_old_info(self) -> dict:
+        """
+        Check if a detected disk has old RAID information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "is_disk_detected_old_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_migrate(self) -> dict:
+        """
+        Migrate a storage pool to a different RAID type.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "migrate",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_pause_data_scrubbing(self) -> dict:
+        """
+        Pause an ongoing data scrubbing operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "pause_data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_pre_delete_check(self) -> dict:
+        """
+        Check if a pool can be safely deleted.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "pre_delete_check",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_reassemble(self) -> dict:
+        """
+        Re-assemble a pool from detected disks.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "reassemble",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_remove_missing_pool(self) -> dict:
+        """
+        Remove a missing storage pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove_missing_pool",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_remove_raid_sb_cache(self) -> dict:
+        """
+        Remove RAID superblock cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "remove_raid_sb_cache",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_repair(self) -> dict:
+        """
+        Repair a degraded storage pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "repair",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_replace(self) -> dict:
+        """
+        Replace a failing disk in a storage pool with a new one.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "replace",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_set_setting(self) -> dict:
+        """
+        Configure advanced storage pool settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_setting",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def pool_update_raid_sb_cache(self) -> dict:
+        """
+        Update RAID superblock cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Pool``.
+        """
+        api_name = "SYNO.Storage.CGI.Pool"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "update_raid_sb_cache",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def scrubbing_get_state(self, space_id: str) -> dict:
+        """
+        SYNO.Storage.CGI.Scrubbing.get_state
+
+        Parameters
+        ----------
+        space_id : str
+            Storage space/volume identifier to query scrubbing state for.
+
+        Returns
+        -------
+        dict
+            Scrubbing state for the specified space.
+        """
+        api_name = "SYNO.Storage.CGI.Scrubbing"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_state",
+            "version": 1,
+            "space_id": space_id,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def smart_get_health_info(self) -> dict:
+        """
+        Get storage health information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Smart``.
+        """
+        api_name = "SYNO.Storage.CGI.Smart"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_health_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def smart_get_latest_online_drive_db_info(self) -> dict:
+        """
+        Get the latest online drive database info.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Smart``.
+        """
+        api_name = "SYNO.Storage.CGI.Smart"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_latest_online_drive_db_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def smart_get_smart_info(self) -> dict:
+        """
+        Get S.M.A.R.T. information for all disks.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Smart``.
+        """
+        api_name = "SYNO.Storage.CGI.Smart"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_smart_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def smart_list(self) -> dict:
+        """
+        List all entries.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Smart``.
+        """
+        api_name = "SYNO.Storage.CGI.Smart"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def smart_secure_erase(self) -> dict:
+        """
+        Securely erase a disk in the pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Smart``.
+        """
+        api_name = "SYNO.Storage.CGI.Smart"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "secure_erase",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def smart_smart_warning_get(self) -> dict:
+        """
+        Get S.M.A.R.T. warning settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Smart``.
+        """
+        api_name = "SYNO.Storage.CGI.Smart"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "smart_warning_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def smart_smart_warning_set(self) -> dict:
+        """
+        Configure S.M.A.R.T. warning settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Smart``.
+        """
+        api_name = "SYNO.Storage.CGI.Smart"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "smart_warning_set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def smart_update_smartctl_db(self) -> dict:
+        """
+        Update the smartctl drive database.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Smart``.
+        """
+        api_name = "SYNO.Storage.CGI.Smart"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "update_smartctl_db",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def spare_conf_get(self) -> dict:
+        """
+        Get detailed information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Spare.Conf``.
+        """
+        api_name = "SYNO.Storage.CGI.Spare.Conf"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def spare_conf_set(self) -> dict:
+        """
+        Set spare disk configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Spare.Conf``.
+        """
+        api_name = "SYNO.Storage.CGI.Spare.Conf"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def taipei_enclosure_load(self) -> dict:
+        """
+        Load/retrieve all entries.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.TaipeiEnclosure``.
+        """
+        api_name = "SYNO.Storage.CGI.TaipeiEnclosure"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "load",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_cancel_data_scrubbing(self) -> dict:
+        """
+        Cancel volume data scrubbing.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "cancel_data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_cancel_defrag(self) -> dict:
+        """
+        Cancel an ongoing defragmentation operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "cancel_defrag",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_cancel_fs_scrubbing(self) -> dict:
+        """
+        Cancel an ongoing file-system scrubbing operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "cancel_fs_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_change_recovery_key(self) -> dict:
+        """
+        Change the encryption key vault recovery key.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "change_recovery_key",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_clean_dek(self) -> dict:
+        """
+        Clean DEK (Data Encryption Key) entries.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "clean_dek",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_convert_shr_to_pool(self) -> dict:
+        """
+        Convert SHR to a storage pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "convert_shr_to_pool",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_convert_shr_without_drive(self) -> dict:
+        """
+        Convert SHR to a pool without adding drives.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "convert_shr_without_drive",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_create(self) -> dict:
+        """
+        Create a new volume on the NAS.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_create_on_existing_pool(self) -> dict:
+        """
+        Create a volume on an existing pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "create_on_existing_pool",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_data_scrubbing(self) -> dict:
+        """
+        Get/set data scrubbing status for the volume.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_defrag(self) -> dict:
+        """
+        Start a defragmentation operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "defrag",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_delete(self) -> dict:
+        """
+        Delete an existing volume (destructive).
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "delete",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_deploy_unused(self) -> dict:
+        """
+        Deploy unused disk space to a volume.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "deploy_unused",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_disable_space_usage(self) -> dict:
+        """
+        Disable Btrfs space usage tracking.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "disable_space_usage",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_enable_space_usage(self) -> dict:
+        """
+        Enable Btrfs space usage tracking.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "enable_space_usage",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_enum_resource(self) -> dict:
+        """
+        Enumerate resources in a volume.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "enum_resource",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_estimate_size(self) -> dict:
+        """
+        Estimate volume size after changes.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "estimate_size",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_expand_by_add_disk(self) -> dict:
+        """
+        Expand a volume by adding disks.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "expand_by_add_disk",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_expand_pool_child(self) -> dict:
+        """
+        Expand a child of the storage pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "expand_pool_child",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_expand_unallocated(self) -> dict:
+        """
+        Expand a volume using unallocated space.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "expand_unallocated",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_expand_unfinished_shr(self) -> dict:
+        """
+        Resume interrupted SHR volume expansion.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "expand_unfinished_shr",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_export_recovery_key(self) -> dict:
+        """
+        Export the encryption vault recovery key.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "export_recovery_key",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_failover_keep_rw(self) -> dict:
+        """
+        Fail over to secondary enclosure while keeping read-write.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "failover_keep_rw",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_fs_info_on_pool_meta_set(self) -> dict:
+        """
+        Set file-system info on pool metadata.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "fs_info_on_pool_meta_set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_fs_info_on_pool_meta_update(self) -> dict:
+        """
+        Update file-system info on pool metadata.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "fs_info_on_pool_meta_update",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_fs_scrubbing(self) -> dict:
+        """
+        Start a file-system scrubbing operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "fs_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_get_dump_volumes(self) -> dict:
+        """
+        Get dump/backup volume information for flash cache.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_dump_volumes",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_get_recovery_key(self) -> dict:
+        """
+        Get the encryption key vault recovery key.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_recovery_key",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_get_recovery_key_info(self) -> dict:
+        """
+        Get information about the vault recovery key.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_recovery_key_info",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_get_space_usage(self) -> dict:
+        """
+        Get Btrfs deduplication space usage statistics.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_space_usage",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_migrate(self) -> dict:
+        """
+        Migrate a volume to a different configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "migrate",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_next_trim_time_get(self) -> dict:
+        """
+        Get the next scheduled TRIM time for a volume.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "next_trim_time_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_pause_data_scrubbing(self) -> dict:
+        """
+        Pause volume data scrubbing.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "pause_data_scrubbing",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_pre_delete_check(self) -> dict:
+        """
+        Check if a volume can be safely deleted.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "pre_delete_check",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_repair(self) -> dict:
+        """
+        Repair a degraded volume.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "repair",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_set_dek(self) -> dict:
+        """
+        Set a DEK (Data Encryption Key) entry.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_dek",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_set_setting(self) -> dict:
+        """
+        Configure advanced volume settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_setting",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_ssd_trim_get(self) -> dict:
+        """
+        Get SSD TRIM configuration for the pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "ssd_trim_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_ssd_trim_save(self) -> dict:
+        """
+        Save SSD TRIM configuration for the pool.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "ssd_trim_save",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_transfer_to_rw(self) -> dict:
+        """
+        Transfer volume to read-write mode.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "transfer_to_rw",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_unlock_by_recovery_key(self) -> dict:
+        """
+        Unlock the encryption vault using the recovery key.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "unlock_by_recovery_key",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_unlock_by_vault(self) -> dict:
+        """
+        Unlock the encryption vault using a vault key.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "unlock_by_vault",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_unlock_by_vault_password_key(self) -> dict:
+        """
+        Unlock the encryption vault using a vault password key.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "unlock_by_vault_password_key",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_vol_extent_size_get(self) -> dict:
+        """
+        Get volume extent size configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "vol_extent_size_get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_vol_extent_size_set(self) -> dict:
+        """
+        Set volume extent size configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "vol_extent_size_set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_installer_quick_create(self) -> dict:
+        """
+        Quick create.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume.Installer``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume.Installer"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "quick_create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_installer_quick_create_precheck(self) -> dict:
+        """
+        Quick create precheck.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume.Installer``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume.Installer"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "quick_create_precheck",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_offline_execute(self) -> dict:
+        """
+        Execute the pending offline volume operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume.OfflineOp``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume.OfflineOp"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "execute",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_offline_pre_estimate(self) -> dict:
+        """
+        Pre estimate.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume.OfflineOp``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume.OfflineOp"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "pre_estimate",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def volume_offline_stop(self) -> dict:
+        """
+        Stop the current operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Storage.CGI.Volume.OfflineOp``.
+        """
+        api_name = "SYNO.Storage.CGI.Volume.OfflineOp"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "stop",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)

--- a/synology_api/core_storage.py
+++ b/synology_api/core_storage.py
@@ -77,7 +77,8 @@ class CoreStorage(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def storage_disk_fw_upgrade_start(self, disk_id: str) -> dict[str, object] | str:
+    def storage_disk_fw_upgrade_start(
+            self, disk_id: str) -> dict[str, object] | str:
         """
         Start a disk firmware upgrade.
 
@@ -513,7 +514,8 @@ class CoreStorage(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def recycle_bin_clean(self, share_name: Optional[str] = None) -> dict[str, object] | str:
+    def recycle_bin_clean(
+            self, share_name: Optional[str] = None) -> dict[str, object] | str:
         """
         Empty the recycle bin.
 
@@ -2747,7 +2749,7 @@ class CoreStorage(base_api.BaseApi):
 
     def scrubbing_get_state(self, space_id: str) -> dict:
         """
-        SYNO.Storage.CGI.Scrubbing.get_state
+        Get the current data scrubbing state for a storage space.
 
         Parameters
         ----------

--- a/synology_api/core_sys_info.py
+++ b/synology_api/core_sys_info.py
@@ -1678,14 +1678,22 @@ class SysInfo(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    # TODO {'error': {'code': 103}, 'success': False}
-    '''def domain_info(self) -> dict[str, object] | str:
+    def domain_info(self) -> dict[str, object] | str:
+        """
+        Get domain directory information.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Domain info. Currently returns ``{'enable_domain': False}`` on DS218+.
+        """
         api_name = 'SYNO.Core.Directory.Domain'
         info = self.core_list[api_name]
         api_path = info['path']
-        req_param = {'version': info['maxVersion'], 'method': 'get', 'get': {'additional': 'true'}}
+        req_param = {'version': info['minVersion'], 'method': 'get',
+                     'get': {'additional': 'true'}}
 
-        return self.request_data(api_name, api_path, req_param)'''
+        return self.request_data(api_name, api_path, req_param)
 
     def sso_iwa_info(self) -> dict[str, object] | str:
         """
@@ -1792,17 +1800,53 @@ class SysInfo(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    # TODO {'error': {'code': 101}, 'success': False}
-    '''def upgrade_schedule_set(self, week_day=4, hour=4, minute=10) -> dict[str, object] | str:
+    def upgrade_setting_get(self) -> dict[str, object] | str:
+        """
+        Get upgrade settings.
+
+        Returns current ``autoupdate_type``, ``schedule``, and
+        ``smart_nano_enabled``. The only field settable via the API on
+        DS218+ is ``smart_nano_enabled`` — see ``upgrade_smart_nano_set``.
+
+        Returns
+        -------
+        dict[str, object] or str
+
+            - ``autoupdate_type`` : str — e.g. ``"hotfix-security"``
+            - ``schedule`` : dict — ``week_day``, ``hour``, ``minute``
+            - ``smart_nano_enabled`` : bool
+        """
         api_name = 'SYNO.Core.Upgrade.Setting'
         info = self.core_list[api_name]
         api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'get'}
 
-        schedule = {'week_day': '4', 'hour': 4, 'minute': 10}
-        req_param = {'version': info['maxVersion'], 'method': 'set', 'autoupdate_type': 'hotfix-security',
-                     'schedule': schedule}
+        return self.request_data(api_name, api_path, req_param)
 
-        return self.request_data(api_name, api_path, req_param)'''
+    def upgrade_smart_nano_set(self, enabled: bool) -> dict[str, object] | str:
+        """
+        Enable or disable Smart Nano updates.
+
+        This is the only writable field of ``SYNO.Core.Upgrade.Setting``.
+        ``autoupdate_type`` and ``schedule`` are read-only.
+
+        Parameters
+        ----------
+        enabled : bool
+            ``True`` to enable, ``False`` to disable.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API response.
+        """
+        api_name = 'SYNO.Core.Upgrade.Setting'
+        info = self.core_list[api_name]
+        api_path = info['path']
+        req_param = {'version': info['maxVersion'], 'method': 'set',
+                     'smart_nano_enabled': enabled}
+
+        return self.request_data(api_name, api_path, req_param)
 
     def auto_upgrade_status(self) -> dict[str, object] | str:
         """

--- a/synology_api/core_sys_info.py
+++ b/synology_api/core_sys_info.py
@@ -1,5 +1,5 @@
 """
-Synology Core System Information API wrapper.
+Synology Core System Information + API Info wrapper.
 
 This module provides a Python interface for retrieving and managing system information
 on Synology NAS devices, including network, hardware, service, and package status.
@@ -2017,4 +2017,240 @@ class SysInfo(base_api.BaseApi):
         info = self.core_list[api_name]
         api_path = info['path']
         req_param = {'version': info['maxVersion'], 'method': 'status'}
+        return self.request_data(api_name, api_path, req_param)
+
+    def dsm_findme_start(self) -> dict:
+        """
+        Start snapshot usage tracking.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DSM.FindMe``.
+        """
+        api_name = "SYNO.DSM.FindMe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "start",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dsm_findme_stop(self) -> dict:
+        """
+        Stop snapshot usage tracking.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DSM.FindMe``.
+        """
+        api_name = "SYNO.DSM.FindMe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "stop",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dsm_findme_supported(self) -> dict:
+        """
+        Check which email providers are supported.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DSM.FindMe``.
+        """
+        api_name = "SYNO.DSM.FindMe"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "supported",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dsm_network_list(self) -> dict:
+        """
+        List snapshot usage entries.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DSM.Network``.
+        """
+        api_name = "SYNO.DSM.Network"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 2,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dsm_port_is_pkg_enable(self, service: str) -> dict:
+        """
+        SYNO.DSM.PortEnable.is_pkg_enable
+
+        Parameters
+        ----------
+        service : str
+            Service name (e.g. ``"ssh"``, ``"ftp"``, ``"http"``).
+
+        Returns
+        -------
+        dict
+            Whether the service package is enabled on this port.
+        """
+        api_name = "SYNO.DSM.PortEnable"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "is_pkg_enable",
+            "version": 1,
+            "service": service,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dsm_port_is_port_block(self, service: str) -> dict:
+        """
+        SYNO.DSM.PortEnable.is_port_block
+
+        Parameters
+        ----------
+        service : str
+            Service name (e.g. ``"ssh"``, ``"ftp"``, ``"http"``).
+
+        Returns
+        -------
+        dict
+            Whether the port is blocked for this service.
+        """
+        api_name = "SYNO.DSM.PortEnable"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "is_port_block",
+            "version": 1,
+            "service": service,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def dsm_port_open_block_port(self) -> dict:
+        """
+        Open a block port in the network firewall.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.DSM.PortEnable``.
+        """
+        api_name = "SYNO.DSM.PortEnable"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "open_block_port",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+
+
+# ------------------------------------------------------------------
+# API Info / Entry Request Polling
+# ------------------------------------------------------------------
+
+class CoreApiInfo(base_api.BaseApi):
+    """
+    Core API Info wrapper for API discovery and entry request polling.
+
+    Covers SYNO.API.Info (query, Query) and SYNO.Entry.Request.Polling
+    (list, status) endpoints.
+    """
+
+    # SYNO.API.Info
+    # ------------------------------------------------------------------
+
+    def api_query(self, query: str = "all") -> dict[str, object] | str:
+        """Query available DSM APIs.
+
+        Parameters
+        ----------
+        query : str
+            API name to query, or ``"all"`` for all registered APIs.
+
+        Returns
+        -------
+        dict[str, object] or str
+            API info for the requested API name(s).
+        """
+        api_name = 'SYNO.API.Info'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'query',
+            'query': query,
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def api_info(self) -> dict[str, object] | str:
+        """Get full API info (capital-Q Query variant).
+
+        Returns
+        -------
+        dict[str, object] or str
+            Complete API info response.
+        """
+        api_name = 'SYNO.API.Info'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'Query',
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    # SYNO.Entry.Request.Polling
+    # ------------------------------------------------------------------
+
+    def request_poll_list(self) -> dict[str, object] | str:
+        """List pending entry request polling tasks.
+
+        Returns
+        -------
+        dict[str, object] or str
+            List of polling tasks.
+        """
+        api_name = 'SYNO.Entry.Request.Polling'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'list',
+        }
+
+        return self.request_data(api_name, api_path, req_param)
+
+    def request_poll_status(self) -> dict[str, object] | str:
+        """Get status of entry request polling tasks.
+
+        Returns
+        -------
+        dict[str, object] or str
+            Polling status information.
+        """
+        api_name = 'SYNO.Entry.Request.Polling'
+        info = self.gen_list[api_name]
+        api_path = info['path']
+        req_param = {
+            'version': info['maxVersion'],
+            'method': 'status',
+        }
+
         return self.request_data(api_name, api_path, req_param)

--- a/synology_api/core_sys_info.py
+++ b/synology_api/core_sys_info.py
@@ -794,7 +794,8 @@ class SysInfo(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     # coolfan , fullfan
-    def set_fan_speed(self, fan_speed: str = 'quietfan') -> dict[str, object] | str:
+    def set_fan_speed(
+            self, fan_speed: str = 'quietfan') -> dict[str, object] | str:
         """
         Set hardware fan speed.
 
@@ -901,7 +902,8 @@ class SysInfo(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def set_led_control(self, led_brightness: int = 2) -> dict[str, object] | str:
+    def set_led_control(
+            self, led_brightness: int = 2) -> dict[str, object] | str:
         """
         Set LED brightness.
 
@@ -923,7 +925,8 @@ class SysInfo(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def set_hibernation(self, internal_hd_idletime: int = 0, usb_idletime: int = 0) -> dict[str, object] | str:
+    def set_hibernation(self, internal_hd_idletime: int = 0,
+                        usb_idletime: int = 0) -> dict[str, object] | str:
         """
         Set hibernation times.
 
@@ -1015,7 +1018,8 @@ class SysInfo(base_api.BaseApi):
         api_path = info['path']
         req_param = {'version': info['maxVersion'], 'method': 'info'}
 
-        return self.request_data(api_name, api_path, req_param)['data']['sys_temp']
+        return self.request_data(api_name, api_path, req_param)[
+            'data']['sys_temp']
 
     def get_all_system_utilization(self) -> str:
         """
@@ -1079,7 +1083,8 @@ class SysInfo(base_api.BaseApi):
         api_path = info['path']
         req_param = {'version': info['maxVersion'], 'method': 'get'}
 
-        return self.request_data(api_name, api_path, req_param)['data']['memory']
+        return self.request_data(api_name, api_path, req_param)[
+            'data']['memory']
 
     def shutdown(self, version: str = None) -> dict[str, object] | str:
         """
@@ -1623,7 +1628,8 @@ class SysInfo(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def groups_info(self, offset: int = 0, limit: int = -1, name_only: bool = False) -> dict[str, object] | str:
+    def groups_info(self, offset: int = 0, limit: int = -1,
+                    name_only: bool = False) -> dict[str, object] | str:
         """
         Get groups information.
 
@@ -1745,7 +1751,8 @@ class SysInfo(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def gateway_list(self, ip_type: str = 'ipv4', type: str = 'wan') -> dict[str, object] | str:
+    def gateway_list(self, ip_type: str = 'ipv4',
+                     type: str = 'wan') -> dict[str, object] | str:
         """
         Get gateway list.
 
@@ -2093,7 +2100,7 @@ class SysInfo(base_api.BaseApi):
 
     def dsm_port_is_pkg_enable(self, service: str) -> dict:
         """
-        SYNO.DSM.PortEnable.is_pkg_enable
+        Check if a DSM service package is enabled on a network port.
 
         Parameters
         ----------
@@ -2117,7 +2124,7 @@ class SysInfo(base_api.BaseApi):
 
     def dsm_port_is_port_block(self, service: str) -> dict:
         """
-        SYNO.DSM.PortEnable.is_port_block
+        Check if a network port is blocked for a given DSM service.
 
         Parameters
         ----------
@@ -2158,7 +2165,6 @@ class SysInfo(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
 
-
 # ------------------------------------------------------------------
 # API Info / Entry Request Polling
 # ------------------------------------------------------------------
@@ -2175,7 +2181,8 @@ class CoreApiInfo(base_api.BaseApi):
     # ------------------------------------------------------------------
 
     def api_query(self, query: str = "all") -> dict[str, object] | str:
-        """Query available DSM APIs.
+        """
+        Query available DSM APIs.
 
         Parameters
         ----------
@@ -2199,7 +2206,8 @@ class CoreApiInfo(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def api_info(self) -> dict[str, object] | str:
-        """Get full API info (capital-Q Query variant).
+        """
+        Get full API info (capital-Q Query variant).
 
         Returns
         -------
@@ -2220,7 +2228,8 @@ class CoreApiInfo(base_api.BaseApi):
     # ------------------------------------------------------------------
 
     def request_poll_list(self) -> dict[str, object] | str:
-        """List pending entry request polling tasks.
+        """
+        List pending entry request polling tasks.
 
         Returns
         -------
@@ -2238,7 +2247,8 @@ class CoreApiInfo(base_api.BaseApi):
         return self.request_data(api_name, api_path, req_param)
 
     def request_poll_status(self) -> dict[str, object] | str:
-        """Get status of entry request polling tasks.
+        """
+        Get status of entry request polling tasks.
 
         Returns
         -------

--- a/synology_api/core_system.py
+++ b/synology_api/core_system.py
@@ -840,3 +840,201 @@ class CoreSystem(base_api.BaseApi):
         req_param.update(kwargs)
 
         return self.request_data(api_name, api_path, req_param)
+
+    def socketio_emit(self) -> dict:
+        """
+        Emit/send a snapshot event notification.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Entry.SocketIo``.
+        """
+        api_name = "SYNO.Entry.SocketIo"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "emit",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def socketio_listeners_count(self) -> dict:
+        """
+        Get the current number of active Socket.IO listeners.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Entry.SocketIo``.
+        """
+        api_name = "SYNO.Entry.SocketIo"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "listeners_count",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def license_ha_get_uuid(self) -> dict:
+        """
+        Get the Taipei enclosure UUID.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.License.HA``.
+        """
+        api_name = "SYNO.License.HA"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_uuid",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def license_ha_ha_remote_login(self) -> dict:
+        """
+        Perform a remote login via High Availability credential.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.License.HA``.
+        """
+        api_name = "SYNO.License.HA"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "ha_remote_login",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def license_ha_save_vault(self) -> dict:
+        """
+        Save/persist the encryption key vault configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.License.HA``.
+        """
+        api_name = "SYNO.License.HA"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "save_vault",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def remote_credential_set(self) -> dict:
+        """
+        Set or update the configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Remote.Credential``.
+        """
+        api_name = "SYNO.Remote.Credential"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def remote_credential_challenge_get(self) -> dict:
+        """
+        Get remote credential challenge parameters.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Remote.Credential.Challenge``.
+        """
+        api_name = "SYNO.Remote.Credential.Challenge"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def remote_credential_info_get(self) -> dict:
+        """
+        Get remote credential service information.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Remote.Credential.Info``.
+        """
+        api_name = "SYNO.Remote.Credential.Info"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def remote_credential_verifier_get(self) -> dict:
+        """
+        Get remote credential verifier status.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Remote.Credential.Verifier``.
+        """
+        api_name = "SYNO.Remote.Credential.Verifier"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def videoplayer_subtitle_get(self) -> dict:
+        """
+        Get VideoPlayer subtitle configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.VideoPlayer.Subtitle``.
+        """
+        api_name = "SYNO.VideoPlayer.Subtitle"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def videoplayer_drive_subtitle_get(self) -> dict:
+        """
+        Get Synology Drive VideoPlayer subtitle settings.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.VideoPlayer.SynologyDrive.Subtitle``.
+        """
+        api_name = "SYNO.VideoPlayer.SynologyDrive.Subtitle"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)

--- a/synology_api/core_user.py
+++ b/synology_api/core_user.py
@@ -38,7 +38,7 @@ class User(base_api.BaseApi):
     See individual method docstrings for usage examples.
     """
 
-    def get_users(
+    def user_list(
         self, offset: int = 0, limit: int = -1, sort_by: str = "name", sort_direction: str = "ASC", additional: list[str] = []
     ) -> dict[str, object]:
         """
@@ -121,7 +121,7 @@ class User(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def get_user(self, name: str, additional: list[str] = []) -> dict[str, object]:
+    def user_get(self, name: str, additional: list[str] = []) -> dict[str, object]:
         """
         Retrieve user information.
 
@@ -177,7 +177,7 @@ class User(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def create_user(
+    def user_create(
         self, name: str, password: str, description: str = "", email: str = "", expire: str = "never", cannot_chg_passwd: bool = False,
         passwd_never_expire: bool = True, notify_by_email: bool = False, send_password: bool = False
     ) -> dict[str, object]:
@@ -253,7 +253,7 @@ class User(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param, method="post")
 
-    def modify_user(
+    def user_set(
         self, name: str, new_name: str, password: str = "", description: str = "", email: str = "", expire: str = "never", cannot_chg_passwd: bool = False,
         passwd_never_expire: bool = True, notify_by_email: bool = False, send_password: bool = False
     ) -> dict[str, object]:
@@ -327,7 +327,7 @@ class User(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param, method="post")
 
-    def delete_user(self, name: str) -> dict[str, object]:
+    def user_delete(self, name: str) -> dict[str, object]:
         """
         Delete a user.
 
@@ -364,7 +364,7 @@ class User(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param)
 
-    def affect_groups(self, name: str, join_groups: list[str] = [], leave_groups: list[str] = []) -> dict[str, object]:
+    def user_group_join(self, name: str, join_groups: list[str] = [], leave_groups: list[str] = []) -> dict[str, object]:
         """
         Affect or disaffect groups to a user.
 
@@ -411,7 +411,7 @@ class User(base_api.BaseApi):
         }
         return self.request_data(api_name, api_path, req_param)
 
-    def affect_groups_status(self, task_id: str):
+    def user_group_join_status(self, task_id: str):
         """
         Get the status of a join task.
 
@@ -462,7 +462,7 @@ class User(base_api.BaseApi):
         }
         return self.request_data(api_name, api_path, req_param)
 
-    def get_password_policy(self) -> dict[str, object]:
+    def user_password_policy_get(self) -> dict[str, object]:
         """
         Get the password policy.
 
@@ -504,7 +504,7 @@ class User(base_api.BaseApi):
         }
         return self.request_data(api_name, api_path, req_param)
 
-    def set_password_policy(
+    def user_password_policy_set(
         self, enable_reset_passwd_by_email: bool = False, password_must_change: bool = False,
         exclude_username: bool = True, included_numeric_char: bool = True, included_special_char: bool = False,
         min_length: int = 8, min_length_enable: bool = True, mixed_case: bool = True,
@@ -575,7 +575,7 @@ class User(base_api.BaseApi):
         }
         return self.request_data(api_name, api_path, req_param)
 
-    def get_password_expiry(self) -> dict[str, object]:
+    def user_password_expiry_get(self) -> dict[str, object]:
         """
         Get the password expiry.
 
@@ -612,7 +612,7 @@ class User(base_api.BaseApi):
         }
         return self.request_data(api_name, api_path, req_param)
 
-    def set_password_expiry(
+    def user_password_expiry_set(
         self, password_expire_enable: bool = False, max_age: int = 30, min_age_enable: bool = False, min_age: int = 1,
         enable_login_prompt: bool = False, login_prompt_days: int = 1, allow_reset_after_expired: bool = True,
         enable_mail_notification: bool = False, never_expired_list: list[str] = []
@@ -717,7 +717,7 @@ class User(base_api.BaseApi):
 
         return self.request_data(api_name, api_path, req_param, method="post")
 
-    def get_username_policy(self) -> dict[str, object]:
+    def user_username_policy_get(self) -> dict[str, object]:
         """
         Get the username policy (list of usernames that are not usable).
 
@@ -744,5 +744,134 @@ class User(base_api.BaseApi):
         req_param = {
             "method": "list",
             "version": info['minVersion']
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+class PersonMailAccount(base_api.BaseApi):
+    """Synology Personal Mail Account API wrapper."""
+
+    def mail_contacts_list(self) -> dict:
+        """
+        List snapshot usage entries.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.PersonMailAccount.Contacts``.
+        """
+        api_name = "SYNO.PersonMailAccount.Contacts"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def mail_clean(self) -> dict:
+        """
+        Clean/reset the remote credential verifier.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.PersonMailAccount.Mail``.
+        """
+        api_name = "SYNO.PersonMailAccount.Mail"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "clean",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def mail_send(self) -> dict:
+        """
+        Send an email from the person mail account.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.PersonMailAccount.Mail``.
+        """
+        api_name = "SYNO.PersonMailAccount.Mail"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "send",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def mail_status(self) -> dict:
+        """
+        Get snapshot usage tracking status.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.PersonMailAccount.Mail``.
+        """
+        api_name = "SYNO.PersonMailAccount.Mail"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "status",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def mail_stop(self) -> dict:
+        """
+        Stop snapshot usage tracking.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.PersonMailAccount.Mail``.
+        """
+        api_name = "SYNO.PersonMailAccount.Mail"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "stop",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def mail_oauth_gmail(self) -> dict:
+        """
+        Configure Gmail as the person mail account.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.PersonMailAccount.Mail.Oauth``.
+        """
+        api_name = "SYNO.PersonMailAccount.Mail.Oauth"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "gmail",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def mail_oauth_outlook(self) -> dict:
+        """
+        Configure Outlook as the person mail account.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.PersonMailAccount.Mail.Oauth``.
+        """
+        api_name = "SYNO.PersonMailAccount.Mail.Oauth"
+        info = self.core_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "outlook",
+            "version": 1,
         }
         return self.request_data(api_name, api_path, req_param)

--- a/synology_api/core_user.py
+++ b/synology_api/core_user.py
@@ -747,6 +747,7 @@ class User(base_api.BaseApi):
         }
         return self.request_data(api_name, api_path, req_param)
 
+
 class PersonMailAccount(base_api.BaseApi):
     """Synology Personal Mail Account API wrapper."""
 

--- a/synology_api/security_advisor.py
+++ b/synology_api/security_advisor.py
@@ -122,3 +122,93 @@ class SecurityAdvisor(base_api.BaseApi):
                      'method': 'group_enum', 'argGroup': 'custom'}
 
         return self.request_data(api_name, api_path, req_param)
+
+    def advisor_alert_set(self) -> dict:
+        """
+        Set or update the configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.SecurityAdvisor.Conf.Checklist.Alert``.
+        """
+        api_name = "SYNO.SecurityAdvisor.Conf.Checklist.Alert"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def advisor_login_get(self) -> dict:
+        """
+        Get user login activity log from Security Advisor.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.SecurityAdvisor.LoginActivity.User``.
+        """
+        api_name = "SYNO.SecurityAdvisor.LoginActivity.User"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def advisor_report_create(self) -> dict:
+        """
+        Create a new user group.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.SecurityAdvisor.Report``.
+        """
+        api_name = "SYNO.SecurityAdvisor.Report"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "create",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def advisor_report_list(self) -> dict:
+        """
+        List snapshot usage entries.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.SecurityAdvisor.Report``.
+        """
+        api_name = "SYNO.SecurityAdvisor.Report"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "list",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def advisor_report_html_open(self) -> dict:
+        """
+        Open a snapshot usage tracking session.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.SecurityAdvisor.Report.HTML``.
+        """
+        api_name = "SYNO.SecurityAdvisor.Report.HTML"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "open",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)

--- a/synology_api/snapshot.py
+++ b/synology_api/snapshot.py
@@ -1156,3 +1156,129 @@ class Snapshot(base_api.BaseApi):
         }
 
         return self.request_data(api_name, api_path, req_param)
+
+    def snap_usage_cancel(self) -> dict:
+        """
+        Cancel an offline volume operation.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Snap.Usage.Share``.
+        """
+        api_name = "SYNO.Snap.Usage.Share"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "cancel",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def snap_usage_clean(self) -> dict:
+        """
+        Clean/reset the remote credential verifier.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Snap.Usage.Share``.
+        """
+        api_name = "SYNO.Snap.Usage.Share"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "clean",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def snap_usage_get_conf(self) -> dict:
+        """
+        Get the Btrfs deduplication configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Snap.Usage.Share``.
+        """
+        api_name = "SYNO.Snap.Usage.Share"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_conf",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def snap_usage_get_report(self) -> dict:
+        """
+        Generate a snapshot space usage report per share.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Snap.Usage.Share``.
+        """
+        api_name = "SYNO.Snap.Usage.Share"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "get_report",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def snap_usage_set_conf(self) -> dict:
+        """
+        Set the Btrfs deduplication configuration.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Snap.Usage.Share``.
+        """
+        api_name = "SYNO.Snap.Usage.Share"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "set_conf",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def snap_usage_start(self) -> dict:
+        """
+        Start snapshot usage tracking.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Snap.Usage.Share``.
+        """
+        api_name = "SYNO.Snap.Usage.Share"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "start",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)
+
+    def snap_usage_status(self) -> dict:
+        """
+        Get snapshot usage tracking status.
+
+        Returns
+        -------
+        dict
+            API response from ``SYNO.Snap.Usage.Share``.
+        """
+        api_name = "SYNO.Snap.Usage.Share"
+        info = self.gen_list[api_name]
+        api_path = info["path"]
+        req_param = {
+            "method": "status",
+            "version": 1,
+        }
+        return self.request_data(api_name, api_path, req_param)


### PR DESCRIPTION
Add a large set of convenience wrapper methods for various Synology APIs. Changes include:

- audiostation: add stream and transcode methods for SYNO.AudioPlayer.Stream.
- core_backup: add many Hyper Backup and AutoBackup/Restore/Config endpoints, S2S server methods, and Disaster Recovery / Snapshot Replication (DR) wrappers (node, credential, session, log, retention).
- core_certificate: add CRT certificate operations (create, delete, list, recreate, renew, set).
- core_notification: add push_notification_requesttoken for SYNO.DSM.PushNotification.
- core_security_auth: expand API coverage and docs; add RescueEmail endpoints and SYNO.API.Auth.* helpers (Key, Key.Code, Type, RedirectURI).
- core_storage: add numerous storage-related endpoints (Btrfs dedupe, cache protection, and other storage CGI methods).

All new methods follow existing patterns (using gen_list/core_list, api path lookup and request_data) and provide small, documented wrappers for corresponding SYNO.* API actions.

