### PR TITLE
Documentation tweak

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 #
 Contributing to synology-api
 
-See our [Contribution Guide](https://N4S4.github.io/synology-api/docs/contribute/readme.md) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
+See our [Contribution Guide](https://N4S4.github.io/synology-api/documentation/docs/contribute/readme.md) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
 
 We'd love your help — don't be shy!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 #
 Contributing to synology-api
 
-See our [Contribution Guide](https://N4S4.github.io/synology-api/documentation/docs/contribute/readme.md) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
+See our [Contribution Guide](https://github.com/N4S4/synology-api/blob/master/documentation/docs/contribute/readme.md) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
 
 We'd love your help — don't be shy!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,4 @@
-#
-Contributing to synology-api
+# Contributing to synology-api
 
 See our [Contribution Guide](https://github.com/N4S4/synology-api/blob/master/documentation/docs/contribute/readme.md) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
-# Contributing to synology-api
+#
+Contributing to synology-api
 
-See our [Contribution Guide](https://N4S4.github.io/synology-api/docs/contribute/readme) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
+See our [Contribution Guide](https://N4S4.github.io/synology-api/docs/contribute/readme.md) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
 
 We'd love your help — don't be shy!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to synology-api
 
-See our [Contribution Guide](https://github.com/N4S4/synology-api/blob/master/documentation/docs/contribute/readme.md) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
+See our [Contribution Guide](https://github.com/N4S4/synology-api/documentation/docs/contribute/readme.md) for setup instructions, code formatting, pre-commit hooks, and pull request guidelines.
 
 We'd love your help — don't be shy!


### PR DESCRIPTION
## :card_file_box: Summary

The pull request fixes a broken link in the documenation

---

## :rocket: Motivation & Problem Statement

Ironically, when I went looking to read through the contribution documentation, I found the link to the contribution readme file was broken.  It would appear that the URL fell through the cracks when the documentation was reorganized some time ago.

---

## :wrench: Implementation Details

Changed the link:
- from: https://N4S4.github.io/synology-api/docs/contribute/readme
- to: https://github.com/N4S4/synology-api/blob/master/documentation/docs/contribute/readme.md

---

## :checkered_flag: Checklist

- [x ] I have read and followed the [Contributing guidelines](https://N4S4.github.io/synology-api/docs/contribute/readme).
- [ n/a] All new or modified code is covered by unit tests (`tests/`).
- [ n/a] Tests pass locally (`pytest`).
- [ n/a] I added or updated documentation where necessary.
- [ n/a] I updated the changelog or added a new section if this is a major change.
- [ n/a] I followed the style guidelines (`black`, `flake8`, etc.).
- [ n/a] I ran `pre-commit` and addressed any linting issues.

> **Note:** If you added a new API wrapper, please update `docs/` and add the
> corresponding entries to `APIs - Supported APIs` in the README.

---

## :memo: Related Issue

n/a

---

## :hammer: Additional Notes

n/a

---

## :sunglasses: Test & Build Status

No code changes

---

## :eyes: Screenshots / Media

n/a

---

Thank you for contributing! 🙏
